### PR TITLE
Critical CKAN File Fix

### DIFF
--- a/ForAllKerbalkind.ckan
+++ b/ForAllKerbalkind.ckan
@@ -121,7 +121,7 @@
         },
         {
             "name": "RealismOverhaul",
-            "version": "v17.18.0.0",
+            "version": "v17.17.0.0",
             "suppress_recommendations": true
         },
         {

--- a/ForAllKerbalkind.ckan
+++ b/ForAllKerbalkind.ckan
@@ -4,7 +4,7 @@
     "name": "For All Kerbalkind",
     "abstract": "One small installation for a Kerbal, one giant modpack for all Kerbalkind!",
     "author": "The Beardy Penguin",
-    "version": "1.5.4",
+    "version": "1.6.1",
     "ksp_version_min": "1.12.3",
     "ksp_version_max": "1.12.5",
     "license": "MIT",

--- a/GameData/ForAllKerbalkind/ForAllKerbalkind.version
+++ b/GameData/ForAllKerbalkind/ForAllKerbalkind.version
@@ -2,7 +2,7 @@
   "NAME": "ForAllKerbalkind",
   "URL": "https://github.com/TheBeardyPenguin/ForAllKerbalkind",
   "DOWNLOAD": "https://github.com/TheBeardyPenguin/ForAllKerbalkind/releases",
-  "VERSION": {"MAJOR": 1, "MINOR": 6, "PATCH": 0, "BUILD": 0},
+  "VERSION": {"MAJOR": 1, "MINOR": 6, "PATCH": 1, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 12, "PATCH": 5},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 12, "PATCH": 3},
   "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 12, "PATCH": 99}


### PR DESCRIPTION
[Critical fix, as discussed in N9's Discord Server.](https://discord.com/channels/343801441095516160/750049648441294952/1362757975722295467)

This rolls back the version of ``Realism Overhaul`` in the Modpack's ``.ckan`` installer file to ``v17.17``, which should address broken dependencies which seemed to have been retroactively applied to ``v17.18``.

**This should hopefully un-break the install.**
### Hopefully.