### PR TITLE
CWSC/ESA Engines: Add Waterfall Support & Fix ullage

### DIFF
--- a/GameData/ForAllKerbalkind/Config/Fixes/P241UllageFix.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/P241UllageFix.cfg
@@ -2,7 +2,7 @@
 //
 //	Fixes the Ariane P-241/P-EAP SRM falsely having an ullage requirement for some reason.
 //
-//	By YoshiWooof22
+//	By YoshiWoof22
 //	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
 //	====================================================================
 

--- a/GameData/ForAllKerbalkind/Config/Fixes/P241UllageFix.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/P241UllageFix.cfg
@@ -1,0 +1,22 @@
+//	[ FAK | CWSC/ESA | P-241 Ullage Fix ]
+//
+//	Fixes the Ariane P-241/P-EAP SRM falsely having an ullage requirement for some reason.
+//
+//	By YoshiWooof22
+//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//	====================================================================
+
+
+//	==================
+//	[Fix & remove ullage requirement from P241/P-EAP SRM]
+//	==================
+//
+@PART[*]:HAS[#engineType[EAP-241]]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        @CONFIG,* {
+            %ullage = False
+        }
+    }
+}

--- a/GameData/ForAllKerbalkind/Config/Visuals/Waterfall_CWSC_Engines.cfg
+++ b/GameData/ForAllKerbalkind/Config/Visuals/Waterfall_CWSC_Engines.cfg
@@ -18,13 +18,20 @@
         template = rowaterfall-hybrid-srm-1
         useHybrid = true
         audio = srm-2
-        position = 0, 0.06, 1
-        rotation = 3, 0, 0
+        position = 0, 0, 0.8
+        rotation = 0, 0, 0
         scale = 4, 4, 5
         useRelativeScaling = true
-        glow = ro-srm
+        //glow = ro-srm
         glowStretch = 0.1
-	rowaterfallKeep = true
+	    rowaterfallKeep = true
+        ExtraTemplate
+		{
+			template = ro-srm
+			position = 0, 0, 0.8
+		   	rotation = 0, 0, 0
+		   	scale = 2.444, 2.444, 0.49
+		}
     }
 }
 

--- a/GameData/ForAllKerbalkind/Config/Visuals/Waterfall_CWSC_Engines.cfg
+++ b/GameData/ForAllKerbalkind/Config/Visuals/Waterfall_CWSC_Engines.cfg
@@ -1,0 +1,59 @@
+//	[ FAK | CWSC/ESA | P-241 & Vulcain Waterfall Support ]
+//
+//	Adds Waterfall support to the Vulcain Ariane and P241/P-EAP SRMs.
+//
+//	By YoshiWooof22
+//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//	====================================================================
+
+
+//	==================
+//	[Add WF support to P-241/P-EAP SRM]
+//	==================
+//
+@PART[*]:HAS[#engineType[EAP-241]]:BEFORE[ROWaterfall]:NEEDS[Waterfall,SmokeScreen]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hybrid-srm-1
+        useHybrid = true
+        audio = srm-2
+        position = 0, 0.06, 1
+        rotation = 3, 0, 0
+        scale = 4, 4, 5
+        useRelativeScaling = true
+        glow = ro-srm
+        glowStretch = 0.1
+	rowaterfallKeep = true
+    }
+}
+
+
+//	==================
+//	[Add WF support to Vulcain]
+//	==================
+//
+@PART[*]:HAS[#engineType[Vulcain]]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+	// Main template based on LR87-LH2
+	ROWaterfall
+    {
+        template = waterfall-hydrolox-lower-4
+        audio = pump-fed-heavy-1
+        position = 0, 0, 0.95
+        rotation = 0, 0, 0
+        scale = 1.3, 1.3, 1.3
+        //glow = ro-hydrolox-red-blue
+        glowStretch = 1.25
+		rowaterfallKeep = true
+
+		// Define the engine glow
+		ExtraTemplate
+		{
+			template = ro-hydrolox-red-blue
+			position = 0, 0, 0.985
+		   	rotation = 0, 0, 0
+		   	scale = 1.7, 1.7, 3.936
+		}
+    }
+}

--- a/GameData/ForAllKerbalkind/Config/Visuals/Waterfall_CWSC_Engines.cfg
+++ b/GameData/ForAllKerbalkind/Config/Visuals/Waterfall_CWSC_Engines.cfg
@@ -2,7 +2,7 @@
 //
 //	Adds Waterfall support to the Vulcain Ariane and P241/P-EAP SRMs.
 //
-//	By YoshiWooof22
+//	By YoshiWoof22
 //	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
 //	====================================================================
 


### PR DESCRIPTION
## Summary
Adds Waterfall Plumes to the **Vulcain** Engine & **P-241** SRM (from **_Real Scale Boosters_**) used by Carnasa's **Commonwealth Space Commission / ESA**.

The plumes are not perfect, but they should be "accurate enough" - and they are very visually-appealing, especially compared to the old RealPlume configs.

This PR also fixes the P-241 SRM so it no longer requires ullage, as it is a solid rocket motor.

<sub>You're welcome Carnasa ^^</sub>

## Images
<div align="center">
    <table>
        <tr>
            <td align="center">
                <p><strong>Vulcain | 1atm (Sea Level)</strong></p>
            </td>
            <td align="center">
                <p><strong>Vulcain | 0.4atm</strong></p>
            </td>
            <td align="center">
                <p><strong>Vulcain | 0atm (Vacuum)</strong></p>
            </td>
        </tr>
        <tr>
            <td align="center">
                <img src="https://github.com/user-attachments/assets/b6c59d21-b9d4-4e46-9ceb-d0efb5a74234" alt="1atm" width="250">
            </td>
            <td align="center">
                <img src="https://github.com/user-attachments/assets/1b5de0cd-dbf4-46a1-8d9e-4ca3fa1f04af" alt="0.4atm" width="250">
            </td>
            <td align="center">
                <img src="https://github.com/user-attachments/assets/c5e4be25-119e-48d6-bdf7-1b8ff1589cc0" alt="0atm" width="250">
            </td>
        </tr>
    </table>
</div>
<div align="center">
    <table>
        <tr>
            <td align="center">
                <p><strong>P-214 / P-EAP | 1atm (Sea Level)</strong></p>
            </td>
        </tr>
        <tr>
            <td align="center">
                <img src="https://github.com/user-attachments/assets/72b200eb-8855-40c9-9392-931c23aba41a" alt="0atm" height="500">
            </td>
        </tr>
    </table>
</div>


## Detailed Changes:
- **Vulcain** Engine now has a Waterfall plume:
  - Template is based on the *LR87-LH2* (sea level variant).
  - There is not much footage to go off of for making the plumes look accurate, but what footage exists does show the presence of Mach/Shock Diamonds with a red-ish hue at sea level.
- **P-241/P-EAP** SRM now has a Waterfall-SmokeScreen Hybrid plume.
  - Template is based on the *UA-120X* SRM.
- **P-241/P-EAP** SRM now no longer requires ullage to ignite.
  - Reason: **Why would it need ullage if the propellants are SOLID?!**