### PR TITLE
NK-15VM Tech Node Fix & Assorted Engine Rebalancing

### DIFF
--- a/GameData/ForAllKerbalkind/Config/Career/NewRp1TreeParts.cfg
+++ b/GameData/ForAllKerbalkind/Config/Career/NewRp1TreeParts.cfg
@@ -5063,7 +5063,7 @@
 }
 @PART[ROEE-NK15VM]:AFTER[xxxRP0]
 {
-    %TechRequired = hydrolox1998
+    %TechRequired = hydrolox1972
     %cost = 1400
     %entryCost = 0
     %RP0conf = true

--- a/GameData/ForAllKerbalkind/Config/Fixes/HG3Removal.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/HG3Removal.cfg
@@ -1,0 +1,91 @@
+//	[ FAK | NASA | HG-3 Removal ]
+//
+//	After a LOT of digging and comparisons, we've come to the conclusion that the HG-3 is a redundant engine that (honestly speaking) doesn't really need to exist.
+//	This frees up the part's model, which could be used for alternative engines in the future.
+//
+//	A breakdown of the reasons and arguments is listed in the bullet points below.
+//	Note that some of the original sources cited are paywalled or in books, which contain actual information from involved parties.
+//
+//  1. 	The HG-3 engine was conceived in the 1960s as a hypothetical engine, designed around specifications needed for the Saturn Modified Launch Vehicke (MLV),
+//		Reusable Orbital Transport (ROT) and Advanced Engine Design Studies/Programs.
+//		[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//
+//	2. 	There is a common myth that Rocketdyne developed the HG-3, and exists as the "missing link" between the J-2 and RS-25.
+//		This is completely false: Rocketdyne had no documented affiliation with the HG-3. It was actually a joint effort between MSFC and Pratt & Whitney.
+//		There are more sources confirming Pratt & Whitney's involvement, than there are sources stating Rocketdyne - the only one being Mark Wade.
+//		[ Source: NASA MSFC, Saturn MLV Improvement Study Composite Summary Report, https://ntrs.nasa.gov/api/citations/19650020081/downloads/19650020081.pdf ]
+//		[ Source: NASA MSFC, Contract NAS8-11427 "HG-3 Liquid Rocket Engine Design Study Data Summary", Pratt & Whitney Aircraft Report 1044A ]
+//		[ Source: NASA MSFC, Contract NAS8-11427 "HG-3 Liquid Rocket Engine Design Study èarametric Data Summary", Pratt & Whitney Aircraft Report 1182A ]
+//		[ Source: NASA & T.A. Heppenheimer, "The Space Shuttle Decision: NASA's Search for a Reusable Space Vehicle", https://www.nasa.gov/wp-content/uploads/2023/04/sp-4221.pdf ]
+//
+//	3.	The above is backed up by the fact that Rocketdyne was, at the time of the 1965 MSFC Saturn MLV Upper Stage Study, still working on up-rating the J-2 and F-1.
+//		Both of those engines were part of said study, so it makes little sense for Rocketdyne to also be developing the HG-3 at the same time.
+//		[ Source: NASA MSFC, Saturn MLV Improvement Study Composite Summary Report, https://ntrs.nasa.gov/api/citations/19650020081/downloads/19650020081.pdf ]
+//
+//	4.  A simple comparison between the statistics/specifications of the hypothetical HG-3 and the actually-developed P&W XLR129 shows that both engines are basically identical:
+//		- Both engines stem from Pratt & Whitney.
+//		- Both engines were to use LH2/LOX propellants.
+//		- Both engines were to use a staged combustion cycle (a novel concept at the time, laying a foundation for the SSME program which the LR129 was also proposed for).
+//		- Both engines were to be in the same thrust bracket (300k+ lbf thrust).
+//		- Both engines were to have nearly identical Chamber Pressures (3080psi/20.7MPa), Isp (~450@Vac) and burn times (~500sec).
+//		- Both engines had extendible nozzles (ROEngines fails to model this; likely an oversight).
+//		[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//
+//	5.  The only real difference between the HG-3 and the XLR129 is that the latter was designed to be used on the USAF/CIA ISINGLASS Spaceplane, and saw actual development.
+//		This also checks out, given that ISINGLASS requirements directly contributed to SSME requirements later down the road, which - again - the XLR129 was proposed for.
+//		[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//		[ Source: AIAA, Paper 71-658 "Pratt & Whitney Aircraft's Space Shuttle Main Engine"]
+//
+//	6.	Even looking at Rocketdyne's early SSME development, there is zero reference to an HG-3, and initial proposals also look nothing like it.
+//		This further disproves the myth that the HG-3 is in any way related to the RS-25 Space Shuttle Main Engine, or Rocketdyne, as it would've been referenced.
+//		[ Source: AIAA, Paper 71-659 "Rocketdyne's Space Shuttle Main Engine"]
+//
+//
+//	[ General Summary: ]
+//		- The HG-3 was conceived by P&W as a hypothetical engine for NASA MSFC's MLV and ROT programs, and not by Rocketdyne.
+//		- It was cancelled in favour of up-rating Rocketdyne's J-2 and other engines that were already further along in development.
+//		- Not wanting to waste their existing results, P&W looked to the CIA/USAF and their planned ISINGLASS spaceplane.
+//		- ISINGLASS needed an engine with similar specifications to the ones outlined for the original HG-3 proposed for Saturn MLV.
+//		- P&W took their existing "work" on the HG-3 and instead applied it to ISINGLASS, resulting in the XLR129 being developed.
+//		- Conclusion: The HG-3 didn't really exist, as it actually just became the XLR129.
+//
+//
+//	====================================================================
+//	By YoshiWoof22
+//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//	====================================================================
+
+
+//	==================
+//	[Deprecate the HG-3 Part]
+//	> To ensure that existing crafts can be loaded and migrated, we're only removing the part from the Tech Tree.
+//	==================
+//
+@PART[ROE-HG3]:LAST[xxxRP0] {
+	@title = HG-3 (DEPRECATED)
+	@manufacturer = #roMfrPW
+    @description = 1965 proposal by Pratt & Whitney for a hypothetical 350k-lbf class upper stage hydrolox engine, using a staged combustion cycle. Development cancelled after initial study evaluation, later resumed as the LR129 for the CIA/USAF ISINGLASS Spaceplane.\n<b><color=red>Part deprecated by For All Kerbalkind. Use the LR129 instead!</color></b>
+	%RP0conf = false
+	%RSSROConfig = false
+	%TechRequired = orphanParts
+}
+
+
+//	==================
+//	[Deprecate the HG-3 Part Configs]
+//	> The configs themselves are still in the game (again for backwards compatibility), but no longer in the normally-accessible Tech Tree.
+//	> Sidenote: Whose bright idea was it to give a HYPOTHETICAL engine more configs than its real counterpart? There were like 8 configs for this thing, why??
+//	==================
+//
+-PARTUPGRADE[RFUpgrade_HG-3*]:LAST[RealismOverhaulEngines] {}
+
+@PART[*]:HAS[#engineType[HG3]]:AFTER[RealismOverhaulEnginesPost]
+{
+	@MODULE[Module*EngineConfigs],*
+	{
+		@CONFIG[HG-3*]
+		{
+			%techRequired = orphanParts
+		}
+	}
+}

--- a/GameData/ForAllKerbalkind/Config/Fixes/HG3Removal.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/HG3Removal.cfg
@@ -1,91 +1,91 @@
-//	[ FAK | NASA | HG-3 Removal ]
+//    [ FAK | NASA | HG-3 Removal ]
 //
-//	After a LOT of digging and comparisons, we've come to the conclusion that the HG-3 is a redundant engine that (honestly speaking) doesn't really need to exist.
-//	This frees up the part's model, which could be used for alternative engines in the future.
+//    After a LOT of digging and comparisons, we've come to the conclusion that the HG-3 is a redundant engine that (honestly speaking) doesn't really need to exist.
+//    This frees up the part's model, which could be used for alternative engines in the future.
 //
-//	A breakdown of the reasons and arguments is listed in the bullet points below.
-//	Note that some of the original sources cited are paywalled or in books, which contain actual information from involved parties.
+//    A breakdown of the reasons and arguments is listed in the bullet points below.
+//    Note that some of the original sources cited are paywalled or in books, which contain actual information from involved parties.
 //
-//  1. 	The HG-3 engine was conceived in the 1960s as a hypothetical engine, designed around specifications needed for the Saturn Modified Launch Vehicke (MLV),
-//		Reusable Orbital Transport (ROT) and Advanced Engine Design Studies/Programs.
-//		[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//    1.  The HG-3 engine was conceived in the 1960s as a hypothetical engine, designed around specifications needed for the Saturn Modified Launch Vehicke (MLV),
+//        Reusable Orbital Transport (ROT) and Advanced Engine Design Studies/Programs.
+//        [ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
 //
-//	2. 	There is a common myth that Rocketdyne developed the HG-3, and exists as the "missing link" between the J-2 and RS-25.
-//		This is completely false: Rocketdyne had no documented affiliation with the HG-3. It was actually a joint effort between MSFC and Pratt & Whitney.
-//		There are more sources confirming Pratt & Whitney's involvement, than there are sources stating Rocketdyne - the only one being Mark Wade.
-//		[ Source: NASA MSFC, Saturn MLV Improvement Study Composite Summary Report, https://ntrs.nasa.gov/api/citations/19650020081/downloads/19650020081.pdf ]
-//		[ Source: NASA MSFC, Contract NAS8-11427 "HG-3 Liquid Rocket Engine Design Study Data Summary", Pratt & Whitney Aircraft Report 1044A ]
-//		[ Source: NASA MSFC, Contract NAS8-11427 "HG-3 Liquid Rocket Engine Design Study èarametric Data Summary", Pratt & Whitney Aircraft Report 1182A ]
-//		[ Source: NASA & T.A. Heppenheimer, "The Space Shuttle Decision: NASA's Search for a Reusable Space Vehicle", https://www.nasa.gov/wp-content/uploads/2023/04/sp-4221.pdf ]
+//    2.  There is a common myth that Rocketdyne developed the HG-3, and exists as the "missing link" between the J-2 and RS-25.
+//        This is completely false: Rocketdyne had no documented affiliation with the HG-3. It was actually a joint effort between MSFC and Pratt & Whitney.
+//        There are more sources confirming Pratt & Whitney's involvement, than there are sources stating Rocketdyne - the only one being Mark Wade.
+//        [ Source: NASA MSFC, Saturn MLV Improvement Study Composite Summary Report, https://ntrs.nasa.gov/api/citations/19650020081/downloads/19650020081.pdf ]
+//        [ Source: NASA MSFC, Contract NAS8-11427 "HG-3 Liquid Rocket Engine Design Study Data Summary", Pratt & Whitney Aircraft Report 1044A ]
+//        [ Source: NASA MSFC, Contract NAS8-11427 "HG-3 Liquid Rocket Engine Design Study èarametric Data Summary", Pratt & Whitney Aircraft Report 1182A ]
+//        [ Source: NASA & T.A. Heppenheimer, "The Space Shuttle Decision: NASA's Search for a Reusable Space Vehicle", https://www.nasa.gov/wp-content/uploads/2023/04/sp-4221.pdf ]
 //
-//	3.	The above is backed up by the fact that Rocketdyne was, at the time of the 1965 MSFC Saturn MLV Upper Stage Study, still working on up-rating the J-2 and F-1.
-//		Both of those engines were part of said study, so it makes little sense for Rocketdyne to also be developing the HG-3 at the same time.
-//		[ Source: NASA MSFC, Saturn MLV Improvement Study Composite Summary Report, https://ntrs.nasa.gov/api/citations/19650020081/downloads/19650020081.pdf ]
+//    3.  The above is backed up by the fact that Rocketdyne was, at the time of the 1965 MSFC Saturn MLV Upper Stage Study, still working on up-rating the J-2 and F-1.
+//        Both of those engines were part of said study, so it makes little sense for Rocketdyne to also be developing the HG-3 at the same time.
+//        [ Source: NASA MSFC, Saturn MLV Improvement Study Composite Summary Report, https://ntrs.nasa.gov/api/citations/19650020081/downloads/19650020081.pdf ]
 //
-//	4.  A simple comparison between the statistics/specifications of the hypothetical HG-3 and the actually-developed P&W XLR129 shows that both engines are basically identical:
-//		- Both engines stem from Pratt & Whitney.
-//		- Both engines were to use LH2/LOX propellants.
-//		- Both engines were to use a staged combustion cycle (a novel concept at the time, laying a foundation for the SSME program which the LR129 was also proposed for).
-//		- Both engines were to be in the same thrust bracket (300k+ lbf thrust).
-//		- Both engines were to have nearly identical Chamber Pressures (3080psi/20.7MPa), Isp (~450@Vac) and burn times (~500sec).
-//		- Both engines had extendible nozzles (ROEngines fails to model this; likely an oversight).
-//		[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//    4.  A simple comparison between the statistics/specifications of the hypothetical HG-3 and the actually-developed P&W XLR129 shows that both engines are basically identical:
+//        - Both engines stem from Pratt & Whitney.
+//        - Both engines were to use LH2/LOX propellants.
+//        - Both engines were to use a staged combustion cycle (a novel concept at the time, laying a foundation for the SSME program which the LR129 was also proposed for).
+//        - Both engines were to be in the same thrust bracket (300k+ lbf thrust).
+//        - Both engines were to have nearly identical Chamber Pressures (3080psi/20.7MPa), Isp (~450@Vac) and burn times (~500sec).
+//        - Both engines had extendible nozzles (ROEngines fails to model this; likely an oversight).
+//        [ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
 //
-//	5.  The only real difference between the HG-3 and the XLR129 is that the latter was designed to be used on the USAF/CIA ISINGLASS Spaceplane, and saw actual development.
-//		This also checks out, given that ISINGLASS requirements directly contributed to SSME requirements later down the road, which - again - the XLR129 was proposed for.
-//		[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
-//		[ Source: AIAA, Paper 71-658 "Pratt & Whitney Aircraft's Space Shuttle Main Engine"]
+//    5.  The only real difference between the HG-3 and the XLR129 is that the latter was designed to be used on the USAF/CIA ISINGLASS Spaceplane, and saw actual development.
+//        This also checks out, given that ISINGLASS requirements directly contributed to SSME requirements later down the road, which - again - the XLR129 was proposed for.
+//        [ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//        [ Source: AIAA, Paper 71-658 "Pratt & Whitney Aircraft's Space Shuttle Main Engine"]
 //
-//	6.	Even looking at Rocketdyne's early SSME development, there is zero reference to an HG-3, and initial proposals also look nothing like it.
-//		This further disproves the myth that the HG-3 is in any way related to the RS-25 Space Shuttle Main Engine, or Rocketdyne, as it would've been referenced.
-//		[ Source: AIAA, Paper 71-659 "Rocketdyne's Space Shuttle Main Engine"]
-//
-//
-//	[ General Summary: ]
-//		- The HG-3 was conceived by P&W as a hypothetical engine for NASA MSFC's MLV and ROT programs, and not by Rocketdyne.
-//		- It was cancelled in favour of up-rating Rocketdyne's J-2 and other engines that were already further along in development.
-//		- Not wanting to waste their existing results, P&W looked to the CIA/USAF and their planned ISINGLASS spaceplane.
-//		- ISINGLASS needed an engine with similar specifications to the ones outlined for the original HG-3 proposed for Saturn MLV.
-//		- P&W took their existing "work" on the HG-3 and instead applied it to ISINGLASS, resulting in the XLR129 being developed.
-//		- Conclusion: The HG-3 didn't really exist, as it actually just became the XLR129.
+//    6.  Even looking at Rocketdyne's early SSME development, there is zero reference to an HG-3, and initial proposals also look nothing like it.
+//        This further disproves the myth that the HG-3 is in any way related to the RS-25 Space Shuttle Main Engine, or Rocketdyne, as it would've been referenced.
+//        [ Source: AIAA, Paper 71-659 "Rocketdyne's Space Shuttle Main Engine"]
 //
 //
-//	====================================================================
-//	By YoshiWoof22
-//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
-//	====================================================================
+//    [ General Summary: ]
+//        - The HG-3 was conceived by P&W as a hypothetical engine for NASA MSFC's MLV and ROT programs, and not by Rocketdyne.
+//        - It was cancelled in favour of up-rating Rocketdyne's J-2 and other engines that were already further along in development.
+//        - Not wanting to waste their existing results, P&W looked to the CIA/USAF and their planned ISINGLASS spaceplane.
+//        - ISINGLASS needed an engine with similar specifications to the ones outlined for the original HG-3 proposed for Saturn MLV.
+//        - P&W took their existing "work" on the HG-3 and instead applied it to ISINGLASS, resulting in the XLR129 being developed.
+//        - Conclusion: The HG-3 didn't really exist, as it actually just became the XLR129.
+//
+//
+//  ====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//  ====================================================================
 
 
-//	==================
-//	[Deprecate the HG-3 Part]
-//	> To ensure that existing crafts can be loaded and migrated, we're only removing the part from the Tech Tree.
-//	==================
+//  ==================
+//  [Deprecate the HG-3 Part]
+//  > To ensure that existing crafts can be loaded and migrated, we're only removing the part from the Tech Tree.
+//  ==================
 //
 @PART[ROE-HG3]:LAST[xxxRP0] {
-	@title = HG-3 (DEPRECATED)
-	@manufacturer = #roMfrPW
+    @title = HG-3 (DEPRECATED)
+    @manufacturer = #roMfrPW
     @description = 1965 proposal by Pratt & Whitney for a hypothetical 350k-lbf class upper stage hydrolox engine, using a staged combustion cycle. Development cancelled after initial study evaluation, later resumed as the LR129 for the CIA/USAF ISINGLASS Spaceplane.\n<b><color=red>Part deprecated by For All Kerbalkind. Use the LR129 instead!</color></b>
-	%RP0conf = false
-	%RSSROConfig = false
-	%TechRequired = orphanParts
+    %RP0conf = false
+    %RSSROConfig = false
+    %TechRequired = orphanParts
 }
 
 
-//	==================
-//	[Deprecate the HG-3 Part Configs]
-//	> The configs themselves are still in the game (again for backwards compatibility), but no longer in the normally-accessible Tech Tree.
-//	> Sidenote: Whose bright idea was it to give a HYPOTHETICAL engine more configs than its real counterpart? There were like 8 configs for this thing, why??
-//	==================
+//  ==================
+//  [Deprecate the HG-3 Part Configs]
+//  > The configs themselves are still in the game (again for backwards compatibility), but no longer in the normally-accessible Tech Tree.
+//  > Sidenote: Whose bright idea was it to give a HYPOTHETICAL engine more configs than its real counterpart? There were like 8 configs for this thing, why??
+//  ==================
 //
 -PARTUPGRADE[RFUpgrade_HG-3*]:LAST[RealismOverhaulEngines] {}
 
 @PART[*]:HAS[#engineType[HG3]]:AFTER[RealismOverhaulEnginesPost]
 {
-	@MODULE[Module*EngineConfigs],*
-	{
-		@CONFIG[HG-3*]
-		{
-			%techRequired = orphanParts
-		}
-	}
+    @MODULE[Module*EngineConfigs],*
+    {
+        @CONFIG[HG-3*]
+        {
+            %techRequired = orphanParts
+        }
+    }
 }

--- a/GameData/ForAllKerbalkind/Config/Fixes/LR129Rebalance.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/LR129Rebalance.cfg
@@ -1,281 +1,281 @@
-//	[ FAK | NASA | LR129 Rebalance ]
+//  [ FAK | NASA | LR129 Rebalance ]
 //
-//	Gives the LR129 additional Engine Configs to incorporate some P&W SSME proposals and their specifications.
-//	Also adds and adjusts descriptions, tech nodes, engine specs and PartUpgrade definitions where applicable.
-//	
-//	[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
-//	[ Source: NASA & T.A. Heppenheimer, "The Space Shuttle Decision: NASA's Search for a Reusable Space Vehicle", https://www.nasa.gov/wp-content/uploads/2023/04/sp-4221.pdf ]
-//	[ Source: AIAA, Paper 71-658 "Pratt & Whitney Aircraft's Space Shuttle Main Engine"]
+//  Gives the LR129 additional Engine Configs to incorporate some P&W SSME proposals and their specifications.
+//  Also adds and adjusts descriptions, tech nodes, engine specs and PartUpgrade definitions where applicable.
+//  
+//  [ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//  [ Source: NASA & T.A. Heppenheimer, "The Space Shuttle Decision: NASA's Search for a Reusable Space Vehicle", https://www.nasa.gov/wp-content/uploads/2023/04/sp-4221.pdf ]
+//  [ Source: AIAA, Paper 71-658 "Pratt & Whitney Aircraft's Space Shuttle Main Engine"]
 //
-//	====================================================================
-//	By YoshiWoof22
-//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
-//	====================================================================
+//  ====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//  ====================================================================
 
 
-//	==================
-//	[ LR129 Rebalance & Tweaks ]
-// 	> Adjusts the LR129 and adds new configs for P&W SSME proposals.
-//	==================
+//  ==================
+//  [ LR129 Rebalance & Tweaks ]
+//  > Adjusts the LR129 and adds new configs for P&W SSME proposals.
+//  ==================
 //
 @PART[*]:HAS[#engineType[LR129]]:AFTER[RealismOverhaulEnginesPost]
 {
-        @MODULE[Module*EngineConfigs],*
+    @MODULE[Module*EngineConfigs],*
+    {
+        @CONFIG[XLR129-P-1]
         {
-            @CONFIG[XLR129-P-1]
+            %description = 240K-lbf thrust pre-production prototype, originally developed for the CIA/USAF ISINGLASS Mach 20 rocketplane.\n\n
+        }
+
+        @CONFIG[LR129-P-1]
+        {
+            %description = 250K-lbf thrust production model, originally developed for the CIA/USAF ISINGLASS Mach 20 rocketplane.\n\n
+        }
+
+        @CONFIG[LR129-P-2]
+        {
+            %description = Speculative upgrade, up-rated to achieve a sustained thrust of up to 330K-lbf.\n\n
+        }
+
+        @CONFIG[LR129-P-3]
+        {
+            %description = Speculative upgrade, up-rated even further to 365K-lbf at the cost of long-term engine reliability.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
+            %techRequired = hydrolox1986
+            %specLevel = speculative
+
+            %ullage = False  // Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
+            %pressureFed = False
+            %ignitions = 2  // Single re-light
+
+            %massMult = 1.1592 // Originally 1.0796, but +5% from restart kit, even with mass savings.
+
+            @TESTFLIGHT:NEEDS[TestLite|TestFlight]
             {
-                %description = 240K-lbf thrust pre-production prototype, originally developed for the CIA/USAF ISINGLASS Mach 20 rocketplane.\n\n
-            }
-
-			@CONFIG[LR129-P-1]
-            {
-                %description = 250K-lbf thrust production model, originally developed for the CIA/USAF ISINGLASS Mach 20 rocketplane.\n\n
-            }
-
-			@CONFIG[LR129-P-2]
-            {
-                %description = Speculative upgrade, up-rated to achieve a sustained thrust of up to 330K-lbf.\n\n
-            }
-
-			@CONFIG[LR129-P-3]
-            {
-                %description = Speculative upgrade, up-rated even further to 365K-lbf at the cost of long-term engine reliability.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
-				%techRequired = hydrolox1986
-				%specLevel = speculative
-
-				%ullage = False	// Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
-				%pressureFed = False
-				%ignitions = 2	// Single re-light
-
-				%massMult = 1.1592 // Originally 1.0796, but +5% from restart kit, even with mass savings.
-
-                @TESTFLIGHT:NEEDS[TestLite|TestFlight]
+                restartWindowPenalty                // Minimum 30 minutes between restarts.
                 {
-                    restartWindowPenalty                // Minimum 30 minutes between restarts.
-                    {
-                        key = 0 0 0 0.001767104		    // starts at 0, increases immediately
-                        key = 1800 1 0 0
-                    }
+                    key = 0 0 0 0.001767104        // starts at 0, increases immediately
+                    key = 1800 1 0 0
+                }
+            }
+        }
+
+        CONFIG // Speculative config, based on mid-range P&W SSME proposals (415k-lbf engine).
+        {
+            name = LR129-SSME-A
+            description = Speculative turbopump assembly redesign, proposed for Space Shuttle Phase A development. Capable of achieving sustained thrust up to 415K-lbf, but with slightly reduced efficiency.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
+            techRequired = hydrolox1986
+            specLevel = speculative
+            cost = 1057
+
+            minThrust = 1492.2  // 85%
+            maxThrust = 1755.5
+            massMult = 1.3678 // +13% extra mass compared to P-3, +5% from diminishing returns and restart kit, even with mass savings.
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.7286
+                DrawGauge = true
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2714
+            }
+            atmosphereCurve // Isp based on P&W SSME Study, minimum requirements
+            {
+                key = 0 436
+                key = 1 397 // Interpolated
+            }
+
+            ullage = False  // Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
+            pressureFed = False
+            ignitions = 3  // About on-par with SSME technology-wise. RS-25 150AR Subconfig has 3 ignitions, so base ours on that.
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+            SUBCONFIG
+            {
+                name = LR129-SSME-A-Extended
+                
+                minThrust = 1200.7  // 65%
+                maxThrust = 1847.2
+                
+                atmosphereCurve // Isp based on P&W SSME Study, minimum requirements
+                {
+                    key = 0 456
+                    key = 1 385 // Interpolated
                 }
             }
 
-			CONFIG // Speculative config, based on mid-range P&W SSME proposals (415k-lbf engine).
-			{
-				name = LR129-SSME-A
-				description = Speculative turbopump assembly redesign, proposed for Space Shuttle Phase A development. Capable of achieving sustained thrust up to 415K-lbf, but with slightly reduced efficiency.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
-				techRequired = hydrolox1986
-				specLevel = speculative
-				cost = 1057
+            TESTFLIGHT:NEEDS[TestLite|TestFlight]
+            {
+                testedBurnTime = 4615    // Same as SSME
+                ratedBurnTime = 480
+                overburnPenalty = 1.5    // Keep some penalty, RS25s tended to wear out before 55 mission limit
+                safeOverburn = true
+                
+                // assume roughly exponential relationship between chamber pressure and lifespan
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
 
-				minThrust = 1492.2	// 85%
-				maxThrust = 1755.5
-				massMult = 1.3678 // +13% extra mass compared to P-3, +5% from diminishing returns and restart kit, even with mass savings.
-				PROPELLANT
-				{
-					name = LqdHydrogen
-					ratio = 0.7286
-					DrawGauge = true
-				}
-				PROPELLANT
-				{
-					name = LqdOxygen
-					ratio = 0.2714
-				}
-				atmosphereCurve // Isp based on P&W SSME Study, minimum requirements
-				{
-					key = 0 436
-					key = 1 397 // Interpolated
-				}
-
-				ullage = False	// Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
-				pressureFed = False
-				ignitions = 3	// About on-par with SSME technology-wise. RS-25 150AR Subconfig has 3 ignitions, so base ours on that.
-
-				IGNITOR_RESOURCE
-				{
-					name = ElectricCharge
-					amount = 0.5
-				}
-				SUBCONFIG
-				{
-					name = LR129-SSME-A-Extended
-					
-					minThrust = 1200.7	// 65%
-					maxThrust = 1847.2
-					
-					atmosphereCurve // Isp based on P&W SSME Study, minimum requirements
-					{
-						key = 0 456
-						key = 1 385 // Interpolated
-					}
-				}
-
-				TESTFLIGHT:NEEDS[TestLite|TestFlight]
-				{
-					testedBurnTime = 4615		// Same as SSME
-					ratedBurnTime = 480
-					overburnPenalty = 1.5		// Keep some penalty, RS25s tended to wear out before 55 mission limit
-					safeOverburn = true
-					
-					// assume roughly exponential relationship between chamber pressure and lifespan
-					thrustModifier
-					{
-						key = 0.00 0.05 0 0
-						key = 1.00 1.00 3 3
-					}
-
-					restartWindowPenalty                // Minimum 30 minutes between restarts.
-                    {
-                        key = 0 0 0 0.001767104		    // starts at 0, increases immediately
-                        key = 1800 1 0 0
-                    }
-					
-					ignitionReliabilityStart = 0.9315
-					ignitionReliabilityEnd = 0.9995
-					cycleReliabilityStart = 0.9315
-					cycleReliabilityEnd = 0.9995
-					techTransfer = LR129-P-3,LR129-P-2,LR129-P-1,XLR129-P-1:50
-				}
-			}
-			
-			CONFIG // Even more speculative config, based on later P&W SSME proposals (two-position-nozzle 510-590k-lbf engine. Slightly overkill for this scale, so lets settle for 475k aka RS-25).
-			{
-				name = LR129-SSME-B
-				description = Speculative upgrade proposed for SSME Phase B development, capable of achieving up to 475K-lbf thrust with greater efficiency.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
-				techRequired = hydrolox1992
-				specLevel = speculative
-				cost = 1669
-				// Loosely based on later RS-25 configs
-				minThrust = 1616.9	// 85%
-				maxThrust = 1902.2
-
-				massMult = 1.3678 // Heavy duty.
-				PROPELLANT
-				{
-					name = LqdHydrogen
-					ratio = 0.7286
-					DrawGauge = true
-				}
-				PROPELLANT
-				{
-					name = LqdOxygen
-					ratio = 0.2714
-				}
-				atmosphereCurve // Isp based on P&W SSME Study, optimal
-				{
-					key = 0 441
-					key = 1 397 // Interpolated
-				}
-
-				ullage = False	// Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
-				pressureFed = False
-				ignitions = 3	// About on-par with SSME technology-wise. RS-25 150AR Subconfig has 3 ignitions, so base ours on that.
-
-				IGNITOR_RESOURCE
-				{
-					name = ElectricCharge
-					amount = 0.5
-				}
-				SUBCONFIG
-				{
-					name = LR129-SSME-B-Extended
-					
-					// Loosely based on RS-25, fast-forwarded due to P&W's experience with this kind of engine
-					minThrust = 1273.9	// 65%
-					maxThrust = 2123.1
-					
-					atmosphereCurve // Isp based on P&W SSME Study
-					{
-						key = 0 466
-						key = 1 385 // Interpolated
-					}
-				}
-
-				TESTFLIGHT:NEEDS[TestLite|TestFlight]
-				{
-					testedBurnTime = 4615		//Same as SSME
-					ratedBurnTime = 480
-					overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
-					safeOverburn = true
-					
-					// assume roughly exponential relationship between chamber pressure and lifespan
-					thrustModifier
-					{
-						key = 0.00 0.05 0 0
-						key = 1.00 1.00 3 3
-					}
-
-					restartWindowPenalty                // Minimum 30 minutes between restarts.
-                    {
-                        key = 0 0 0 0.001767104		    // starts at 0, increases immediately
-                        key = 1800 1 0 0
-                    }
-					
-					ignitionReliabilityStart = 0.9315
-					ignitionReliabilityEnd = 0.9995
-					cycleReliabilityStart = 0.9315
-					cycleReliabilityEnd = 0.9995
-					techTransfer = LR129-SSME-A,LR129-P-3,LR129-P-2,LR129-P-1,XLR129-P-1:50
-				}
-			}
+                restartWindowPenalty                // Minimum 30 minutes between restarts.
+                {
+                    key = 0 0 0 0.001767104        // starts at 0, increases immediately
+                    key = 1800 1 0 0
+                }
+                
+                ignitionReliabilityStart = 0.9315
+                ignitionReliabilityEnd = 0.9995
+                cycleReliabilityStart = 0.9315
+                cycleReliabilityEnd = 0.9995
+                techTransfer = LR129-P-3,LR129-P-2,LR129-P-1,XLR129-P-1:50
+            }
         }
+        
+        CONFIG // Even more speculative config, based on later P&W SSME proposals (two-position-nozzle 510-590k-lbf engine. Slightly overkill for this scale, so lets settle for 475k aka RS-25).
+        {
+            name = LR129-SSME-B
+            description = Speculative upgrade proposed for SSME Phase B development, capable of achieving up to 475K-lbf thrust with greater efficiency.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
+            techRequired = hydrolox1992
+            specLevel = speculative
+            cost = 1669
+            // Loosely based on later RS-25 configs
+            minThrust = 1616.9  // 85%
+            maxThrust = 1902.2
+
+            massMult = 1.3678 // Heavy duty.
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.7286
+                DrawGauge = true
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.2714
+            }
+            atmosphereCurve // Isp based on P&W SSME Study, optimal
+            {
+                key = 0 441
+                key = 1 397 // Interpolated
+            }
+
+            ullage = False  // Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
+            pressureFed = False
+            ignitions = 3  // About on-par with SSME technology-wise. RS-25 150AR Subconfig has 3 ignitions, so base ours on that.
+
+            IGNITOR_RESOURCE
+            {
+                name = ElectricCharge
+                amount = 0.5
+            }
+            SUBCONFIG
+            {
+                name = LR129-SSME-B-Extended
+                
+                // Loosely based on RS-25, fast-forwarded due to P&W's experience with this kind of engine
+                minThrust = 1273.9  // 65%
+                maxThrust = 2123.1
+                
+                atmosphereCurve // Isp based on P&W SSME Study
+                {
+                    key = 0 466
+                    key = 1 385 // Interpolated
+                }
+            }
+
+            TESTFLIGHT:NEEDS[TestLite|TestFlight]
+            {
+                testedBurnTime = 4615    //Same as SSME
+                ratedBurnTime = 480
+                overburnPenalty = 1.5    //Keep some penalty, RS25s tended to wear out before 55 mission limit
+                safeOverburn = true
+                
+                // assume roughly exponential relationship between chamber pressure and lifespan
+                thrustModifier
+                {
+                    key = 0.00 0.05 0 0
+                    key = 1.00 1.00 3 3
+                }
+
+                restartWindowPenalty                // Minimum 30 minutes between restarts.
+                {
+                    key = 0 0 0 0.001767104        // starts at 0, increases immediately
+                    key = 1800 1 0 0
+                }
+                
+                ignitionReliabilityStart = 0.9315
+                ignitionReliabilityEnd = 0.9995
+                cycleReliabilityStart = 0.9315
+                cycleReliabilityEnd = 0.9995
+                techTransfer = LR129-SSME-A,LR129-P-3,LR129-P-2,LR129-P-1,XLR129-P-1:50
+            }
+        }
+    }
 }
 
-//	==================
-//	[ LR129 PartUpgrades ]
-// 	> Adds and adjusts the LR129 part upgrade definitions.
-//	==================
+//  ==================
+//  [ LR129 PartUpgrades ]
+//  > Adds and adjusts the LR129 part upgrade definitions.
+//  ==================
 //
 // This is all copy-pasted and adjusted from KclvNewEngines.cfg
 @PARTUPGRADE[RFUpgrade_LR129-P-3]:AFTER[xxxRP0]
 {
-	%techRequired = hydrolox1986
+    %techRequired = hydrolox1986
 }
 PARTUPGRADE
 {
-	name = RFUpgrade_LR129-SSME-A
-	partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-	techRequired = hydrolox1986
-	entryCost = 0
-	cost = 0
-	title = LR129 Engine Upgrade: LR129-SSME-A
-	basicInfo = Engine Performance Upgrade
-	manufacturer = Engine Upgrade
-	deleteme = 1
-	description = The LR129 Engine now supports the LR129-SSME-A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+    name = RFUpgrade_LR129-SSME-A
+    partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+    techRequired = hydrolox1986
+    entryCost = 0
+    cost = 0
+    title = LR129 Engine Upgrade: LR129-SSME-A
+    basicInfo = Engine Performance Upgrade
+    manufacturer = Engine Upgrade
+    deleteme = 1
+    description = The LR129 Engine now supports the LR129-SSME-A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 PARTUPGRADE
 {
-	name = RFUpgrade_LR129-SSME-B
-	partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-	techRequired = hydrolox1992
-	entryCost = 0
-	cost = 0
-	title = LR129 Engine Upgrade: LR129-SSME-B
-	basicInfo = Engine Performance Upgrade
-	manufacturer = Engine Upgrade
-	deleteme = 1
-	description = The LR129 Engine now supports the LR129-SSME-B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+    name = RFUpgrade_LR129-SSME-B
+    partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+    techRequired = hydrolox1992
+    entryCost = 0
+    cost = 0
+    title = LR129 Engine Upgrade: LR129-SSME-B
+    basicInfo = Engine Performance Upgrade
+    manufacturer = Engine Upgrade
+    deleteme = 1
+    description = The LR129 Engine now supports the LR129-SSME-B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
 @PART[*]:HAS[@MODULE[Module*EngineConfigs]]:AFTER[RealismOverhaulEnginesPost]
 {
-	@MODULE[Module*EngineConfigs],*
-	{
-		@CONFIG[LR129-P-3]
-		{
-			%techRequired = hydrolox1986
-			*@PARTUPGRADE[RFUpgrade_LR129-P-3]/deleteme -= 1
-		}
-		@CONFIG[LR129-SSME-A]
-		{
-			%techRequired = hydrolox1986
-			*@PARTUPGRADE[RFUpgrade_LR129-SSME-A]/deleteme -= 1
-		}
-		@CONFIG[LR129-SSME-B]
-		{
-			%techRequired = hydrolox1992
-			*@PARTUPGRADE[RFUpgrade_LR129-SSME-B]/deleteme -= 1
-		}
-	}
+    @MODULE[Module*EngineConfigs],*
+    {
+        @CONFIG[LR129-P-3]
+        {
+            %techRequired = hydrolox1986
+            *@PARTUPGRADE[RFUpgrade_LR129-P-3]/deleteme -= 1
+        }
+        @CONFIG[LR129-SSME-A]
+        {
+            %techRequired = hydrolox1986
+            *@PARTUPGRADE[RFUpgrade_LR129-SSME-A]/deleteme -= 1
+        }
+        @CONFIG[LR129-SSME-B]
+        {
+            %techRequired = hydrolox1992
+            *@PARTUPGRADE[RFUpgrade_LR129-SSME-B]/deleteme -= 1
+        }
+    }
 }

--- a/GameData/ForAllKerbalkind/Config/Fixes/LR129Rebalance.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/LR129Rebalance.cfg
@@ -1,0 +1,281 @@
+//	[ FAK | NASA | LR129 Rebalance ]
+//
+//	Gives the LR129 additional Engine Configs to incorporate some P&W SSME proposals and their specifications.
+//	Also adds and adjusts descriptions, tech nodes, engine specs and PartUpgrade definitions where applicable.
+//	
+//	[ Source: Jenkins, "The Space Shuttle: Developing an Icon; Volume II: Technical Description" ]
+//	[ Source: NASA & T.A. Heppenheimer, "The Space Shuttle Decision: NASA's Search for a Reusable Space Vehicle", https://www.nasa.gov/wp-content/uploads/2023/04/sp-4221.pdf ]
+//	[ Source: AIAA, Paper 71-658 "Pratt & Whitney Aircraft's Space Shuttle Main Engine"]
+//
+//	====================================================================
+//	By YoshiWoof22
+//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//	====================================================================
+
+
+//	==================
+//	[ LR129 Rebalance & Tweaks ]
+// 	> Adjusts the LR129 and adds new configs for P&W SSME proposals.
+//	==================
+//
+@PART[*]:HAS[#engineType[LR129]]:AFTER[RealismOverhaulEnginesPost]
+{
+        @MODULE[Module*EngineConfigs],*
+        {
+            @CONFIG[XLR129-P-1]
+            {
+                %description = 240K-lbf thrust pre-production prototype, originally developed for the CIA/USAF ISINGLASS Mach 20 rocketplane.\n\n
+            }
+
+			@CONFIG[LR129-P-1]
+            {
+                %description = 250K-lbf thrust production model, originally developed for the CIA/USAF ISINGLASS Mach 20 rocketplane.\n\n
+            }
+
+			@CONFIG[LR129-P-2]
+            {
+                %description = Speculative upgrade, up-rated to achieve a sustained thrust of up to 330K-lbf.\n\n
+            }
+
+			@CONFIG[LR129-P-3]
+            {
+                %description = Speculative upgrade, up-rated even further to 365K-lbf at the cost of long-term engine reliability.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
+				%techRequired = hydrolox1986
+				%specLevel = speculative
+
+				%ullage = False	// Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
+				%pressureFed = False
+				%ignitions = 2	// Single re-light
+
+				%massMult = 1.1592 // Originally 1.0796, but +5% from restart kit, even with mass savings.
+
+                @TESTFLIGHT:NEEDS[TestLite|TestFlight]
+                {
+                    restartWindowPenalty                // Minimum 30 minutes between restarts.
+                    {
+                        key = 0 0 0 0.001767104		    // starts at 0, increases immediately
+                        key = 1800 1 0 0
+                    }
+                }
+            }
+
+			CONFIG // Speculative config, based on mid-range P&W SSME proposals (415k-lbf engine).
+			{
+				name = LR129-SSME-A
+				description = Speculative turbopump assembly redesign, proposed for Space Shuttle Phase A development. Capable of achieving sustained thrust up to 415K-lbf, but with slightly reduced efficiency.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
+				techRequired = hydrolox1986
+				specLevel = speculative
+				cost = 1057
+
+				minThrust = 1492.2	// 85%
+				maxThrust = 1755.5
+				massMult = 1.3678 // +13% extra mass compared to P-3, +5% from diminishing returns and restart kit, even with mass savings.
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 0.7286
+					DrawGauge = true
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.2714
+				}
+				atmosphereCurve // Isp based on P&W SSME Study, minimum requirements
+				{
+					key = 0 436
+					key = 1 397 // Interpolated
+				}
+
+				ullage = False	// Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
+				pressureFed = False
+				ignitions = 3	// About on-par with SSME technology-wise. RS-25 150AR Subconfig has 3 ignitions, so base ours on that.
+
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.5
+				}
+				SUBCONFIG
+				{
+					name = LR129-SSME-A-Extended
+					
+					minThrust = 1200.7	// 65%
+					maxThrust = 1847.2
+					
+					atmosphereCurve // Isp based on P&W SSME Study, minimum requirements
+					{
+						key = 0 456
+						key = 1 385 // Interpolated
+					}
+				}
+
+				TESTFLIGHT:NEEDS[TestLite|TestFlight]
+				{
+					testedBurnTime = 4615		// Same as SSME
+					ratedBurnTime = 480
+					overburnPenalty = 1.5		// Keep some penalty, RS25s tended to wear out before 55 mission limit
+					safeOverburn = true
+					
+					// assume roughly exponential relationship between chamber pressure and lifespan
+					thrustModifier
+					{
+						key = 0.00 0.05 0 0
+						key = 1.00 1.00 3 3
+					}
+
+					restartWindowPenalty                // Minimum 30 minutes between restarts.
+                    {
+                        key = 0 0 0 0.001767104		    // starts at 0, increases immediately
+                        key = 1800 1 0 0
+                    }
+					
+					ignitionReliabilityStart = 0.9315
+					ignitionReliabilityEnd = 0.9995
+					cycleReliabilityStart = 0.9315
+					cycleReliabilityEnd = 0.9995
+					techTransfer = LR129-P-3,LR129-P-2,LR129-P-1,XLR129-P-1:50
+				}
+			}
+			
+			CONFIG // Even more speculative config, based on later P&W SSME proposals (two-position-nozzle 510-590k-lbf engine. Slightly overkill for this scale, so lets settle for 475k aka RS-25).
+			{
+				name = LR129-SSME-B
+				description = Speculative upgrade proposed for SSME Phase B development, capable of achieving up to 475K-lbf thrust with greater efficiency.\n\nFitted with an Engine Conditioning System, allowing for on-orbit engine restarts. Minimum of 30 minutes between restarts.\n\n
+				techRequired = hydrolox1992
+				specLevel = speculative
+				cost = 1669
+				// Loosely based on later RS-25 configs
+				minThrust = 1616.9	// 85%
+				maxThrust = 1902.2
+
+				massMult = 1.3678 // Heavy duty.
+				PROPELLANT
+				{
+					name = LqdHydrogen
+					ratio = 0.7286
+					DrawGauge = true
+				}
+				PROPELLANT
+				{
+					name = LqdOxygen
+					ratio = 0.2714
+				}
+				atmosphereCurve // Isp based on P&W SSME Study, optimal
+				{
+					key = 0 441
+					key = 1 397 // Interpolated
+				}
+
+				ullage = False	// Engine conditioning kit with CVS & O2/H2 burner preheater, same as J-2.
+				pressureFed = False
+				ignitions = 3	// About on-par with SSME technology-wise. RS-25 150AR Subconfig has 3 ignitions, so base ours on that.
+
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.5
+				}
+				SUBCONFIG
+				{
+					name = LR129-SSME-B-Extended
+					
+					// Loosely based on RS-25, fast-forwarded due to P&W's experience with this kind of engine
+					minThrust = 1273.9	// 65%
+					maxThrust = 2123.1
+					
+					atmosphereCurve // Isp based on P&W SSME Study
+					{
+						key = 0 466
+						key = 1 385 // Interpolated
+					}
+				}
+
+				TESTFLIGHT:NEEDS[TestLite|TestFlight]
+				{
+					testedBurnTime = 4615		//Same as SSME
+					ratedBurnTime = 480
+					overburnPenalty = 1.5		//Keep some penalty, RS25s tended to wear out before 55 mission limit
+					safeOverburn = true
+					
+					// assume roughly exponential relationship between chamber pressure and lifespan
+					thrustModifier
+					{
+						key = 0.00 0.05 0 0
+						key = 1.00 1.00 3 3
+					}
+
+					restartWindowPenalty                // Minimum 30 minutes between restarts.
+                    {
+                        key = 0 0 0 0.001767104		    // starts at 0, increases immediately
+                        key = 1800 1 0 0
+                    }
+					
+					ignitionReliabilityStart = 0.9315
+					ignitionReliabilityEnd = 0.9995
+					cycleReliabilityStart = 0.9315
+					cycleReliabilityEnd = 0.9995
+					techTransfer = LR129-SSME-A,LR129-P-3,LR129-P-2,LR129-P-1,XLR129-P-1:50
+				}
+			}
+        }
+}
+
+//	==================
+//	[ LR129 PartUpgrades ]
+// 	> Adds and adjusts the LR129 part upgrade definitions.
+//	==================
+//
+// This is all copy-pasted and adjusted from KclvNewEngines.cfg
+@PARTUPGRADE[RFUpgrade_LR129-P-3]:AFTER[xxxRP0]
+{
+	%techRequired = hydrolox1986
+}
+PARTUPGRADE
+{
+	name = RFUpgrade_LR129-SSME-A
+	partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+	techRequired = hydrolox1986
+	entryCost = 0
+	cost = 0
+	title = LR129 Engine Upgrade: LR129-SSME-A
+	basicInfo = Engine Performance Upgrade
+	manufacturer = Engine Upgrade
+	deleteme = 1
+	description = The LR129 Engine now supports the LR129-SSME-A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+PARTUPGRADE
+{
+	name = RFUpgrade_LR129-SSME-B
+	partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+	techRequired = hydrolox1992
+	entryCost = 0
+	cost = 0
+	title = LR129 Engine Upgrade: LR129-SSME-B
+	basicInfo = Engine Performance Upgrade
+	manufacturer = Engine Upgrade
+	deleteme = 1
+	description = The LR129 Engine now supports the LR129-SSME-B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+@PART[*]:HAS[@MODULE[Module*EngineConfigs]]:AFTER[RealismOverhaulEnginesPost]
+{
+	@MODULE[Module*EngineConfigs],*
+	{
+		@CONFIG[LR129-P-3]
+		{
+			%techRequired = hydrolox1986
+			*@PARTUPGRADE[RFUpgrade_LR129-P-3]/deleteme -= 1
+		}
+		@CONFIG[LR129-SSME-A]
+		{
+			%techRequired = hydrolox1986
+			*@PARTUPGRADE[RFUpgrade_LR129-SSME-A]/deleteme -= 1
+		}
+		@CONFIG[LR129-SSME-B]
+		{
+			%techRequired = hydrolox1992
+			*@PARTUPGRADE[RFUpgrade_LR129-SSME-B]/deleteme -= 1
+		}
+	}
+}

--- a/GameData/ForAllKerbalkind/Config/Fixes/NK15VMRebalance.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/NK15VMRebalance.cfg
@@ -1,11 +1,29 @@
-// Tweak NK-15VM engine to have realistic performance
+//	[ FAK | USSR | NK-15VM Rebalance ]
+//
+//	Tweaks the NK-15VM engine to have realistic performance.
+//
+//	====================================================================
+//	By The Beardy Penguin & YoshiWoof22
+//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//	====================================================================
+
+
+//	==================
+//	[ NK-15VM Rebalance ]
+//	> Adjust the performance of the NK-15VM engine to be more realistic
+//	==================
+//
 @PART[ROEE-NK15VM]:AFTER[xxxRP0]
 {
-    @MODULE[ModuleEngineConfigs]
+	@MODULE[ModuleEngineConfigs]
 	{
 		@origMass = 1.5  // Slightly heavier than the NK-15V, similar mass to the J-2
+
 		@CONFIG[NK-15VM]
 		{
+			%techRequired = hydrolox1972	// Fallback definition in case of RP-1 being RP-1 and doing something bad
+			%description = Baseline version derived from the NK-15V, adapted to use LH2/LOX. Proposed for use on improved N1 upper stages, allowing for increased payload capacity.
+			
 			@minThrust = 652	// 50%
 			@maxThrust = 1304	// Calculated by interpolating RD-0120 performance to NK-15V chamber pressure
 			
@@ -21,9 +39,13 @@
 				@testedBurnTime = 450
 				@ratedBurnTime = 346
 			}
-		}	
+		}
+
 		@CONFIG[NK-35]
 		{
+			%techRequired = hydrolox1976	// Fallback definition in case of RP-1 being RP-1 and doing something bad
+			%description = Speculative upgrade with considerably improved reliability. Proposed for use on the UR-700M.
+			
 			@minThrust = 652	// 50%
 			@maxThrust = 1304	// Calculated by interpolating RD-0120 performance to NK-15V chamber pressure
 			
@@ -47,5 +69,36 @@
 		@gimbalRange = 5
 		@useGimbalResponseSpeed = true
 		@gimbalResponseSpeed = 8
+	}
+}
+
+
+//	==================
+//	[ NK-35 Config PartUpgrade]
+// 	> Add a PartUpgrade definition so the engine config actually shows up in the Tech Tree. Why that wasn't the case before is beyond me.
+//	==================
+//
+PARTUPGRADE
+{
+	name = RFUpgrade_NK-15VM-NK-35
+	partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+	techRequired = hydrolox1976 // Where this upgrade shows in the Tech Tree
+	entryCost = 0
+	cost = 0
+	title = NK-15VM Engine Upgrade: NK-35
+	basicInfo = Engine Performance Upgrade
+	manufacturer = Engine Upgrade
+	deleteme = 1
+	description = The NK-15VM Engine now supports the NK-35 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+@PART[*]:HAS[@MODULE[Module*EngineConfigs]]:AFTER[RealismOverhaulEnginesPost]
+{
+	@MODULE[Module*EngineConfigs],*
+	{
+		@CONFIG[NK-35]
+		{
+			*@PARTUPGRADE[RFUpgrade_NK-15VM-NK-35]/deleteme -= 1
+		}
 	}
 }

--- a/GameData/ForAllKerbalkind/Config/Fixes/NK15VMRebalance.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/NK15VMRebalance.cfg
@@ -1,104 +1,104 @@
-//	[ FAK | USSR | NK-15VM Rebalance ]
+//  [ FAK | USSR | NK-15VM Rebalance ]
 //
-//	Tweaks the NK-15VM engine to have realistic performance.
+//  Tweaks the NK-15VM engine to have realistic performance.
 //
-//	====================================================================
-//	By The Beardy Penguin & YoshiWoof22
-//	Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
-//	====================================================================
+//  ====================================================================
+//  By The Beardy Penguin & YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//  ====================================================================
 
 
-//	==================
-//	[ NK-15VM Rebalance ]
-//	> Adjust the performance of the NK-15VM engine to be more realistic
-//	==================
+//  ==================
+//  [ NK-15VM Rebalance ]
+//  > Adjust the performance of the NK-15VM engine to be more realistic
+//  ==================
 //
 @PART[ROEE-NK15VM]:AFTER[xxxRP0]
 {
-	@MODULE[ModuleEngineConfigs]
-	{
-		@origMass = 1.5  // Slightly heavier than the NK-15V, similar mass to the J-2
+    @MODULE[ModuleEngineConfigs]
+    {
+        @origMass = 1.5  // Slightly heavier than the NK-15V, similar mass to the J-2
 
-		@CONFIG[NK-15VM]
-		{
-			%techRequired = hydrolox1972	// Fallback definition in case of RP-1 being RP-1 and doing something bad
-			%description = Baseline version derived from the NK-15V, adapted to use LH2/LOX. Proposed for use on improved N1 upper stages, allowing for increased payload capacity.
-			
-			@minThrust = 652	// 50%
-			@maxThrust = 1304	// Calculated by interpolating RD-0120 performance to NK-15V chamber pressure
-			
-			@atmosphereCurve
-			{
-				@key,0 = 0 445		// Calculated by interpolating RD-0120 performance to NK-15V area ratio
-				@key,1 = 1 344		// Calculated by interpolating RD-0120 sea level thrust loss with constant mass flow rate
-			}
-			@ignitions = 3	// From NK-31 / J-2
-			
-			@TESTFLIGHT
-			{
-				@testedBurnTime = 450
-				@ratedBurnTime = 346
-			}
-		}
+        @CONFIG[NK-15VM]
+        {
+            %techRequired = hydrolox1972  // Fallback definition in case of RP-1 being RP-1 and doing something bad
+            %description = Baseline version derived from the NK-15V, adapted to use LH2/LOX. Proposed for use on improved N1 upper stages, allowing for increased payload capacity.
+            
+            @minThrust = 652  // 50%
+            @maxThrust = 1304  // Calculated by interpolating RD-0120 performance to NK-15V chamber pressure
+            
+            @atmosphereCurve
+            {
+                @key,0 = 0 445  // Calculated by interpolating RD-0120 performance to NK-15V area ratio
+                @key,1 = 1 344  // Calculated by interpolating RD-0120 sea level thrust loss with constant mass flow rate
+            }
+            @ignitions = 3  // From NK-31 / J-2
+            
+            @TESTFLIGHT
+            {
+                @testedBurnTime = 450
+                @ratedBurnTime = 346
+            }
+        }
 
-		@CONFIG[NK-35]
-		{
-			%techRequired = hydrolox1976	// Fallback definition in case of RP-1 being RP-1 and doing something bad
-			%description = Speculative upgrade with considerably improved reliability. Proposed for use on the UR-700M.
-			
-			@minThrust = 652	// 50%
-			@maxThrust = 1304	// Calculated by interpolating RD-0120 performance to NK-15V chamber pressure
-			
-			@atmosphereCurve
-			{
-				@key,0 = 0 445		// Calculated by interpolating RD-0120 performance to NK-15V area ratio
-				@key,1 = 1 344		// Calculated by interpolating RD-0120 sea level thrust loss with constant mass flow rate
-			}
-			@ignitions = 3	// From NK-31 / J-2
-			
-			@TESTFLIGHT
-			{
-				@testedBurnTime = 450
-				@ratedBurnTime = 346
-			}
-		}	
-	}
+        @CONFIG[NK-35]
+        {
+            %techRequired = hydrolox1976  // Fallback definition in case of RP-1 being RP-1 and doing something bad
+            %description = Speculative upgrade with considerably improved reliability. Proposed for use on the UR-700M.
+            
+            @minThrust = 652  // 50%
+            @maxThrust = 1304  // Calculated by interpolating RD-0120 performance to NK-15V chamber pressure
+            
+            @atmosphereCurve
+            {
+                @key,0 = 0 445  // Calculated by interpolating RD-0120 performance to NK-15V area ratio
+                @key,1 = 1 344  // Calculated by interpolating RD-0120 sea level thrust loss with constant mass flow rate
+            }
+            @ignitions = 3  // From NK-31 / J-2
+            
+            @TESTFLIGHT
+            {
+                @testedBurnTime = 450
+                @ratedBurnTime = 346
+            }
+        }
+    }
 
-	@MODULE[ModuleGimbal] // From NK-15V/43
-	{
-		@gimbalRange = 5
-		@useGimbalResponseSpeed = true
-		@gimbalResponseSpeed = 8
-	}
+    @MODULE[ModuleGimbal] // From NK-15V/43
+    {
+        @gimbalRange = 5
+        @useGimbalResponseSpeed = true
+        @gimbalResponseSpeed = 8
+    }
 }
 
 
-//	==================
-//	[ NK-35 Config PartUpgrade]
-// 	> Add a PartUpgrade definition so the engine config actually shows up in the Tech Tree. Why that wasn't the case before is beyond me.
-//	==================
+//  ==================
+//  [ NK-35 Config PartUpgrade]
+//  > Add a PartUpgrade definition so the engine config actually shows up in the Tech Tree. Why that wasn't the case before is beyond me.
+//  ==================
 //
 PARTUPGRADE
 {
-	name = RFUpgrade_NK-15VM-NK-35
-	partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-	techRequired = hydrolox1976 // Where this upgrade shows in the Tech Tree
-	entryCost = 0
-	cost = 0
-	title = NK-15VM Engine Upgrade: NK-35
-	basicInfo = Engine Performance Upgrade
-	manufacturer = Engine Upgrade
-	deleteme = 1
-	description = The NK-15VM Engine now supports the NK-35 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+    name = RFUpgrade_NK-15VM-NK-35
+    partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+    techRequired = hydrolox1976 // Where this upgrade shows in the Tech Tree
+    entryCost = 0
+    cost = 0
+    title = NK-15VM Engine Upgrade: NK-35
+    basicInfo = Engine Performance Upgrade
+    manufacturer = Engine Upgrade
+    deleteme = 1
+    description = The NK-15VM Engine now supports the NK-35 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
 @PART[*]:HAS[@MODULE[Module*EngineConfigs]]:AFTER[RealismOverhaulEnginesPost]
 {
-	@MODULE[Module*EngineConfigs],*
-	{
-		@CONFIG[NK-35]
-		{
-			*@PARTUPGRADE[RFUpgrade_NK-15VM-NK-35]/deleteme -= 1
-		}
-	}
+    @MODULE[Module*EngineConfigs],*
+    {
+        @CONFIG[NK-35]
+        {
+            *@PARTUPGRADE[RFUpgrade_NK-15VM-NK-35]/deleteme -= 1
+        }
+    }
 }


### PR DESCRIPTION
## Summary

1. Fixes the NK-15VM (and NK-35 Upgrade Config) Tech Node placements``*``.
2. Makes the NK-35 Upgrade Config visible in the Tech Tree
3. Deprecates the HG-3 Engine and all its Upgrade Configs``**``.
4. Rebalances the LR129 Engine and also gives it two new Upgrade Configs.

> [!NOTE]
> ``*`` The commit that broke the placements in the first place was 85f4d5675998c2f3c6e4bd849bc976381ad86d3e according to Git-Blame.
> ``**`` The deprecation is **NOT** save- or craft-breaking, and safe to use.

Also as per usual, I did not bump the version numbers because we may end up incorporating further changes before next release.

## Detailed Changes:

### Commit 287003680f495a831c598a3f42ca9d9c6a10d58a:
- Config File has been tweaked to use my standardised config file formatting.
- **NK-15VM** Engine Part and Config are now placed back in the **1972 Hydrolox** Tech Node, where they previously were.
- **NK-15VM: NK-35** Upgrade Config is now placed in the **1976 Hydrolox** Tech Node, where it also previously was.
- **NK-15VM: NK-35** Upgrade Config now has a PartUpgrade definition so it actually shows up in the Tech Tree now.

### Commit 9fc0450f71a8ee6cf3d233ed3cddb6c6adb8b331:
- **HG-3** Engine Part (along with all Upgrade Configs for it) have been deprecated and removed from the Tech Tree.
- For the few people potentially still using it, it remains accessible within the Non-RP1 Orphan Parts node and Sandbox Mode.
- The description and other information of the Engine Part has been adjusted accordingly, and updated to reflect the new sources.
> [!IMPORTANT]
> For further information regarding the reasons and sources used to justify this change, please see the comment within the relevant file. **Seriously, I have spent way too much time searching and evaluating sources for this over the last few weeks, and it is all now neatly listed and documented there for everyone to see.**
> <sub>*This long struggle can now finally come to an end...*</sub>

### Commit 87eacda77f76d0e024276609e51aa91875cbc985:
- **LR129: LR129-P-3** Upgrade Config has been tweaked for adapted upper stage use.
  - This coincidentally also fills the niche left by the deprecation of the HG-3.
- **LR129** now has two new Engine Configs to reflect P&W's SSME development:
  - **LR129-SSME-A**, based on the Pratt & Whitney SSME Phase A proposal.
  - **LR129-SSME-B**, based on the Pratt & Whitney SSME Phase B proposal.
- All LR129 Engines Configs have had their descriptions standardised and changed to match their respective changes.
  