### PR TITLE
1.8.0 - Assorted Fixes and Changes

### DIFF
--- a/ForAllKerbalkind.ckan
+++ b/ForAllKerbalkind.ckan
@@ -470,8 +470,8 @@
             "suppress_recommendations": true
         },
         {
-            "name": "LunarTransferPlanner",
-            "version": "v1.0.0",
+            "name": "TargetInterceptPlanner",
+            "version": "v1.0.1.0",
             "suppress_recommendations": true
         },
         {

--- a/GameData/ForAllKerbalkind/Config/Career/CrewedAsteroidContract.cfg
+++ b/GameData/ForAllKerbalkind/Config/Career/CrewedAsteroidContract.cfg
@@ -1,0 +1,49 @@
+//  [ FAK | Asteroid Contract Requirement Patch ]
+//  
+//  This patch changes crewed asteroid landing contracts to not require a mars landing.
+//	NEO landings are comparable to mars moon landings difficulty-wise, so paralell makes sense.
+//  
+//====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//====================================================================
+
+//==================
+//  Switch Requirement from Crewed Mars Landing to Crewed Repeat/Targeted Moon Landing.
+//==================
+@CONTRACT_TYPE[AsteroidLandingCrew]:LAST[ForAllKerbalkind]
+{
+	// Typo fix
+	@description = Design, build and launch a mission that sends at least two humans to land on an Asteroid and returns them home safely to Earth.\n\nDon't forget that in order to "land" on an Asteroid in KSP terms, you need to use grappling hook and attach yourself to the Asteroid.
+		
+	-REQUIREMENT:HAS[#contractType[MarsLandingCrew]] {}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = RepeatMoonLandingCrew
+	}
+}
+
+//==================
+//  Space Object (Asteroid) Tracking now in TrackingStation Lvl6 / DSN Tech Lvl5
+//	> Advanced Communications Node (1967-1968 / Lunar Exploration Era)
+//==================
+@CUSTOMBARNKIT:LAST[ForAllKerbalkind]
+{
+	@TRACKING
+	{
+		@unlockedSpaceObjectDiscovery = 6
+	}
+}
+
+//==================
+//  Add a note to R&D Node to show you can track asteroids with this.
+//==================
+@TechTree:LAST[ZZZZZ-RP0Tree]
+{
+    @RDNode:HAS[#id[advancedComms]]
+	{
+        @description ^= :$: \n\n<b><color=cyan>Unlocks Tracking Station Level 6, which can track Space Objects like Asteroids.</color></b>
+    }
+}

--- a/GameData/ForAllKerbalkind/Config/Career/CrewedAsteroidContract.cfg
+++ b/GameData/ForAllKerbalkind/Config/Career/CrewedAsteroidContract.cfg
@@ -1,7 +1,7 @@
 //  [ FAK | Asteroid Contract Requirement Patch ]
 //  
 //  This patch changes crewed asteroid landing contracts to not require a mars landing.
-//	NEO landings are comparable to mars moon landings difficulty-wise, so paralell makes sense.
+//	NEO landings are comparable to mars moon landings difficulty-wise, so parallel makes sense.
 //  
 //====================================================================
 //  By YoshiWoof22

--- a/GameData/ForAllKerbalkind/Config/Career/TechTreeRebalance.cfg
+++ b/GameData/ForAllKerbalkind/Config/Career/TechTreeRebalance.cfg
@@ -245,3 +245,13 @@
 {
     %TechRequired = lunarOrbiterCapsules
 }
+
+// Tech Tree
+@TechTree:LAST[ZZZZZ-RP0Tree]
+{
+	// 1980 Hydrolox (SSME) Node -> Remove arbitrary stagedCombustion1972 requirement, since there's staged combustion hydrolox engines in previous nodes.
+    @RDNode:HAS[#id[hydrolox1981]]
+	{
+		-Parent:HAS[#parentID[stagedCombustion1972]],* {}
+	}
+}

--- a/GameData/ForAllKerbalkind/Config/Fixes/AJ260Patch.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/AJ260Patch.cfg
@@ -1,0 +1,108 @@
+//  [ FAK | AJ260 SRM Patch ]
+//  
+//  This patch fixes a TWR issue with the massive AJ260 SRB, and allows it to be more easily recovered as a first stage.
+//  
+//====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//====================================================================
+
+//==================
+//  [AJ260 - Temperature Values]
+//  Increase temperature tolerance to allow gentle re-entries for first stage recovery
+//==================
+@PART[*]:HAS[#engineType[AJ260*]]:AFTER[RealismOverhaulEnginesPost]
+{
+	// Gentle suborbital entries, for SRB recovery.
+	@maxTemp = 3200
+	@skinMaxTemp = 3700
+}
+
+//==================
+//  [AJ260SL - End-of-burn TWR Fix]
+//  The original AJ260 had a high TWR at the end of its burn, which makes it impossible to do hotstaging. Fixed here.
+//==================
+@PART[*]:HAS[#engineType[AJ260SL]]:AFTER[RealismOverhaulEnginesPost]
+{
+	@MODULE[Module*EngineConfigs],*
+	{
+		@CONFIG[AJ260-SL1]
+		{
+			-thrustCurve {}
+			%thrustCurve
+			{
+				key = 1 0.71429
+				key = 0.71429 1 -0.001884577 -0.001884577
+				key = 0.46429 0.88571 -0.01704114 -0.01704114
+				key = 0.21429 0.85714 -0.206599 -0.206599
+				key = 0.14286 0.4 -0.8595195 -0.8595195
+				key = 0.08822 0.38816
+				key = 0.04950 0.31875
+				key = 0.02606 0.17771
+				key = 0.01129 0.10658
+				key = 0.00509 0.03716
+				key = 0.00196 0.01930
+				key = 0.00096 0.01000
+				key = 0.00000 0.01000
+				
+			}
+		}
+
+		@CONFIG[AJ260-SL3]
+		{
+			-thrustCurve {}
+			%thrustCurve
+			{
+				key = 1 0.70755 1.248271 1.248271
+				key = 0.7 1 -0.1455717 -0.1455717
+				key = 0.55 0.83019 -0.02537621 -0.02537621
+				key = 0.26 0.83019 -0.008940977 -0.008940977
+				key = 0.2 0.75472 -3.520613 -3.520613
+				key = 0.15 0.4717 -4.373701 -4.373701
+				key = 0 0.4 -0.8487133 -0.8487133
+				key = 0.08822 0.38816
+				key = 0.04950 0.31875
+				key = 0.02606 0.17771
+				key = 0.01129 0.10658
+				key = 0.00509 0.03716
+				key = 0.00196 0.01930
+				key = 0.00096 0.01000
+				key = 0.00000 0.01000
+				
+			}
+		}
+	}
+}
+
+//==================
+//  [AJ260FL - End-of-burn TWR Fix]
+//  The original AJ260 had a high TWR at the end of its burn, which makes it impossible to do hotstaging. Fixed here.
+//==================
+@PART[*]:HAS[#engineType[AJ260SL]]:AFTER[RealismOverhaulEnginesPost]
+{
+	@MODULE[Module*EngineConfigs],*
+	{
+		@CONFIG[AJ260-FL]
+		{
+			-thrustCurve {}
+			%thrustCurve
+			{
+				key = 1 0.70755 1.248271 1.248271
+				key = 0.7 1 -0.1455717 -0.1455717
+				key = 0.55 0.83019 -0.02537621 -0.02537621
+				key = 0.26 0.83019 -0.008940977 -0.008940977
+				key = 0.2 0.75472 -3.520613 -3.520613
+				key = 0.15 0.4717 -4.373701 -4.373701
+				key = 0.08822 0.38816
+				key = 0.04950 0.31875
+				key = 0.02606 0.17771
+				key = 0.01129 0.10658
+				key = 0.00509 0.03716
+				key = 0.00196 0.01930
+				key = 0.00096 0.01000
+				key = 0.00000 0.01000
+				
+			}
+		}
+	}
+}

--- a/GameData/ForAllKerbalkind/Config/Fixes/ApolloD2Patch.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/ApolloD2Patch.cfg
@@ -1,0 +1,169 @@
+//  [ FAK | Apollo D-2 Part Patch ]
+//  
+//  This patch contains specific targeted fixes for the Apollo D2 Capsule. Fixes include:
+//  - Corrected built-in avionics control mass to account for entry RCS fuel provisions
+//  - EVA fix for the times when you aren't using the mission module
+//  - RCS fix to use historically accurate mixture.
+//  
+//====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//====================================================================
+
+//==================
+//  [D2 CM - Avionics capability fix]
+//  The original 3t of Avionics Control didn't account for ablator, RCS and chute weight, so you couldn't control re-entries. This fixes that critical issue.
+//==================
+@PART[ROC-D2CM]:FINAL
+{
+    %MODULE[ModuleAvionics]
+    {
+        %massLimit = 5
+    }
+}
+
+//==================
+//  [D2 CM - EVA fix]
+//  While D2 has a full EVA airlock in the Mission Module, it doesn't let you EVA if you don't explicitly bring that module.
+//  Still, it does have an egress hatch identical to Apollo, so you should be able to do (emergency) EVAs by depressurising the capsule.
+//  Note; Due to Unity hijinks the egress position is mildly jank, but oh well.
+//==================
+@PART[ROC-D2CM]:FOR[xxxRP0]
+{
+    !MODULE[ModuleNoEVA] {}
+}
+
+//==================
+//  [D2 Parts - Reverting RCS mix back to actual real-life RCS mix]
+//  > Someone in the RO team thinks that D-2 would've used the same RCS fuel mix as the NAA Apollo CM.
+//  > Well, they're wrong. Refer to "GE Project Apollo Data Book Vol. III", Page 205/XIII-11
+//==================
+
+// Command-Descent Module
+@PART[ROC-D2CM]:NEEDS[RealFuels,ROCapsules]:LAST[ROCapsules]
+{
+    @MODULE[ModuleFuelTanks]
+    {
+        @TANK[MMH]
+        {
+            @name = MMH
+            @amount = 46
+            @maxAmount = 46
+        }
+        
+        @TANK[MON1]
+        {
+            @name = NTO
+            @amount = 55
+            @maxAmount = 55
+        }
+        
+        @TANK[Helium]
+        {
+            @name = Helium
+            @amount = 1010
+            @maxAmount = 1010
+        }
+        
+    }
+    
+    @MODULE[ModuleRCSFX]
+    {
+        @PROPELLANT[MMH]
+        {
+            @name = MMH
+            @ratio = 0.456
+        }
+        
+        @PROPELLANT[MON1]
+        {
+            @name = NTO
+            @ratio = 0.544
+        }
+        
+        @PROPELLANT[Helium]
+        {
+            @name = Helium
+            @ratio = 10.0
+        }
+        
+    }
+}
+
+// RCS Pods
+@PART[ROC-D2RCS]:NEEDS[RealFuels,ROCapsules]:LAST[ROCapsules]
+{
+    @MODULE[ModuleRCSFX]
+    {
+        @PROPELLANT[MMH]
+        {
+            @name = MMH
+            @ratio = 0.456
+        }
+        
+        @PROPELLANT[MON1]
+        {
+            @name = NTO
+            @ratio = 0.544
+        }
+        
+        @PROPELLANT[Helium]
+        {
+            @name = Helium
+            @ratio = 10.0
+        }
+    }
+}
+
+// Service Module
+@PART[ROC-D2ServiceModule]:NEEDS[RealFuels,ROCapsules]:LAST[ROCapsules]
+{
+    @MODULE[ModuleFuelTanks]
+    {
+        @TANK[MMH]
+        {
+            @name = MMH
+            @amount = 234.5
+            @maxAmount = 234.5
+        }
+        
+        @TANK[MON1]
+        {
+            @name = NTO
+            @amount = 280.5
+            @maxAmount = 280.5
+        }
+        
+        @TANK[Helium]
+        {
+            @name = Helium
+            @amount = 5160
+            @maxAmount = 5160
+        }
+    }
+}
+
+// Engine Skirts
+@PART[ROC-D2Skirt1,ROC-D2Skirt2]:NEEDS[RealFuels,ROCapsules]:LAST[ROCapsules]
+{
+    @MODULE[ModuleRCSFX]
+    {   
+        @PROPELLANT[MMH]
+        {
+            @name = MMH
+            @ratio = 0.456
+        }
+        
+        @PROPELLANT[MON1]
+        {
+            @name = NTO
+            @ratio = 0.544
+        }
+        
+        @PROPELLANT[Helium]
+        {
+            @name = Helium
+            @ratio = 10.0
+        }
+    }
+}

--- a/GameData/ForAllKerbalkind/Config/Fixes/ApolloD2Patch.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/ApolloD2Patch.cfg
@@ -14,7 +14,7 @@
 //  [D2 CM - Avionics capability fix]
 //  The original 3t of Avionics Control didn't account for ablator, RCS and chute weight, so you couldn't control re-entries. This fixes that critical issue.
 //==================
-@PART[ROC-D2CM]:FINAL
+@PART[ROC-D2CM]:LAST[xxxRP0]
 {
     %MODULE[ModuleAvionics]
     {
@@ -44,47 +44,51 @@
 {
     @MODULE[ModuleFuelTanks]
     {
-        @TANK[MMH]
+        !TANK[*],* {}
+
+        TANK
         {
-            @name = MMH
-            @amount = 46
-            @maxAmount = 46
+            name = MMH
+            amount = 46
+            maxAmount = 46
         }
         
-        @TANK[MON1]
+        TANK
         {
-            @name = NTO
-            @amount = 55
-            @maxAmount = 55
+            name = NTO
+            amount = 55
+            maxAmount = 55
         }
         
-        @TANK[Helium]
+        TANK
         {
-            @name = Helium
-            @amount = 1010
-            @maxAmount = 1010
+            name = Helium
+            amount = 1010
+            maxAmount = 1010
         }
         
     }
     
     @MODULE[ModuleRCSFX]
     {
-        @PROPELLANT[MMH]
+        !PROPELLANT[*],* {}
+        
+        PROPELLANT
         {
-            @name = MMH
-            @ratio = 0.456
+            name = MMH
+            ratio = 0.456
         }
         
-        @PROPELLANT[MON1]
+        PROPELLANT
         {
-            @name = NTO
-            @ratio = 0.544
+            name = NTO
+            ratio = 0.544
         }
         
-        @PROPELLANT[Helium]
+        PROPELLANT
         {
-            @name = Helium
-            @ratio = 10.0
+            name = Helium
+            ratio = 10.0
         }
         
     }
@@ -95,22 +99,24 @@
 {
     @MODULE[ModuleRCSFX]
     {
-        @PROPELLANT[MMH]
+        !PROPELLANT[*],* {}
+        
+        PROPELLANT
         {
-            @name = MMH
-            @ratio = 0.456
+            name = MMH
+            ratio = 0.456
         }
         
-        @PROPELLANT[MON1]
+        PROPELLANT
         {
-            @name = NTO
-            @ratio = 0.544
+            name = NTO
+            ratio = 0.544
         }
         
-        @PROPELLANT[Helium]
+        PROPELLANT
         {
-            @name = Helium
-            @ratio = 10.0
+            name = Helium
+            ratio = 10.0
         }
     }
 }
@@ -120,25 +126,27 @@
 {
     @MODULE[ModuleFuelTanks]
     {
-        @TANK[MMH]
+        !TANK[*],* {}
+
+        TANK
         {
-            @name = MMH
-            @amount = 234.5
-            @maxAmount = 234.5
+            name = MMH
+            amount = 234.5
+            maxAmount = 234.5
         }
         
-        @TANK[MON1]
+        TANK
         {
-            @name = NTO
-            @amount = 280.5
-            @maxAmount = 280.5
+            name = NTO
+            amount = 280.5
+            maxAmount = 280.5
         }
         
-        @TANK[Helium]
+        TANK
         {
-            @name = Helium
-            @amount = 5160
-            @maxAmount = 5160
+            name = Helium
+            amount = 5160
+            maxAmount = 5160
         }
     }
 }
@@ -148,22 +156,24 @@
 {
     @MODULE[ModuleRCSFX]
     {   
-        @PROPELLANT[MMH]
+        !PROPELLANT[*],* {}
+        
+        PROPELLANT
         {
-            @name = MMH
-            @ratio = 0.456
+            name = MMH
+            ratio = 0.456
         }
         
-        @PROPELLANT[MON1]
+        PROPELLANT
         {
-            @name = NTO
-            @ratio = 0.544
+            name = NTO
+            ratio = 0.544
         }
         
-        @PROPELLANT[Helium]
+        PROPELLANT
         {
-            @name = Helium
-            @ratio = 10.0
+            name = Helium
+            ratio = 10.0
         }
     }
 }

--- a/GameData/ForAllKerbalkind/Config/Fixes/IonEngineFix.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/IonEngineFix.cfg
@@ -1,9 +1,7 @@
-//  [ FAK | Apollo D-2 Part Patch ]
+//  [ FAK | Ion Engine Fix ]
 //  
-//  This patch contains specific targeted fixes for the Apollo D2 Capsule. Fixes include:
-//  - Corrected built-in avionics control mass to account for entry RCS fuel provisions
-//  - EVA fix for the times when you aren't using the mission module
-//  - RCS fix to use historically accurate mixture.
+//  This patch rebalances Ion Engines to be actually usable in the pack, given the amount of stuff needed for them.
+//  See notes below for a further explanation.
 //
 //====================================================================
 //  By YoshiWoof22
@@ -13,7 +11,7 @@
 //==================
 //  [Ion Engine Changes]
 //  Ion Engines in standard RO have - as you would expect from RO - realistic thrust levels.
-//  While IRL you can easily do loooooong burns using micronewtons of thrust without issue, the same cannot reasonably be said for KSP (PersistenThrust is not compatible).
+//  While IRL you can easily do loooooong burns using micronewtons of thrust without issue, the same cannot reasonably be said for KSP (PersistentThrust is not compatible).
 //  > This is a game-y compromise; it multiplies thrust & energy consumption, and reduces rated burn time to match; hopefully making Ion Engines actually worthwhile.
 //==================
 

--- a/GameData/ForAllKerbalkind/Config/Fixes/IonEngineFix.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/IonEngineFix.cfg
@@ -12,7 +12,7 @@
 //  [Ion Engine Changes]
 //  Ion Engines in standard RO have - as you would expect from RO - realistic thrust levels.
 //  While IRL you can easily do loooooong burns using micronewtons of thrust without issue, the same cannot reasonably be said for KSP (PersistentThrust is not compatible).
-//  > This is a game-y compromise; it multiplies thrust & energy consumption, and reduces rated burn time to match; hopefully making Ion Engines actually worthwhile.
+//  > This is a game-y compromise; it keeps energy consumption the same, increases thrust, and reduces rated burn time to match; this hopefully makes Ion Engines actually worthwhile.
 //==================
 
 // Tianhe is excluded, it already has kilonewtons of thrust.

--- a/GameData/ForAllKerbalkind/Config/Fixes/IonEngineFix.cfg
+++ b/GameData/ForAllKerbalkind/Config/Fixes/IonEngineFix.cfg
@@ -1,0 +1,40 @@
+//  [ FAK | Apollo D-2 Part Patch ]
+//  
+//  This patch contains specific targeted fixes for the Apollo D2 Capsule. Fixes include:
+//  - Corrected built-in avionics control mass to account for entry RCS fuel provisions
+//  - EVA fix for the times when you aren't using the mission module
+//  - RCS fix to use historically accurate mixture.
+//
+//====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//====================================================================
+
+//==================
+//  [Ion Engine Changes]
+//  Ion Engines in standard RO have - as you would expect from RO - realistic thrust levels.
+//  While IRL you can easily do loooooong burns using micronewtons of thrust without issue, the same cannot reasonably be said for KSP (PersistenThrust is not compatible).
+//  > This is a game-y compromise; it multiplies thrust & energy consumption, and reduces rated burn time to match; hopefully making Ion Engines actually worthwhile.
+//==================
+
+// Tianhe is excluded, it already has kilonewtons of thrust.
+@PART[ionEngine|RO-ionSPT60]:HAS[@MODULE[ModuleEngines*]:HAS[#EngineType[Electric]]]:AFTER[RealismOverhaulEngines]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG,*
+        {
+            @minThrust *= 5000
+            @maxThrust *= 5000
+            
+            @PROPELLANT[ElectricCharge]
+            {
+                @ratio /= 5000 // hundred-watt range
+            }
+            @TESTFLIGHT
+            {
+                @ratedBurnTime /= 500 // Super generous
+            }
+        }
+    }
+}

--- a/GameData/ForAllKerbalkind/Config/Visuals/AJ260NonMetallic.cfg
+++ b/GameData/ForAllKerbalkind/Config/Visuals/AJ260NonMetallic.cfg
@@ -1,0 +1,43 @@
+//  [ FAK | AJ260 Solid Rocket Motor Non-Metallic Shader ]
+//  
+//  This patch makes the AJ260 SRM not look so overly metallic-reflective, to fix an issue with TU/Deferred and having extreme bloom with some TUFX profiles.
+//  
+//====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//====================================================================
+
+//	Remove the old TU effects
+-KSP_MODEL_SHADER[ROE-AJ260] {}
+
+//	Apply not-so-reflective shader to the AJ260
+KSP_MODEL_SHADER
+{
+    name = ROE-AJ260
+
+    model = ROEngines/Assets/BDB/AJ260/bluedog_saturn_AJ260_LongAngled
+    model = ROEngines/Assets/BDB/AJ260/bluedog_saturn_AJ260_LongFlared
+    model = ROEngines/Assets/BDB/AJ260/bluedog_saturn_AJ260_ShortAngled
+    model = ROEngines/Assets/BDB/AJ260/bluedog_saturn_AJ260_ShortFlared
+
+    MATERIAL
+    {
+        shader = TU/Metallic
+
+        PROPERTY
+        {
+            name = _Color
+            color = 1.5, 1.5, 1.5
+        }
+        PROPERTY
+        {
+            name = _Metal
+            float = 0.35
+        }
+        PROPERTY
+        {
+            name = _Smoothness
+            float = 0.35
+        }
+    }
+}

--- a/GameData/ForAllKerbalkind/Config/Visuals/ApolloD2Reflections.cfg
+++ b/GameData/ForAllKerbalkind/Config/Visuals/ApolloD2Reflections.cfg
@@ -1,0 +1,111 @@
+//  [ FAK | Apollo D-2 Part Reflectivity Fix ]
+//  
+//  This patch makes relevant Apollo D-2 part models reflective using TU.
+//  
+//  KNOWN ISSUE:
+//  - Some D-2 parts only use one single model, and thus have the reflectivity applied to parts that probably shouldn't be reflective.
+//  > This is mainly noticable in the Editor. In-game its much more subtle, especially on the D2 CM.
+//  
+//  These *cannot* be fixed without a complete model re-creation, which nobody can really do (needs to be done in Unity iirc).
+//  
+//====================================================================
+//  By YoshiWoof22
+//  Made & tested for the KSP-RO/RP1 "For All Kerbalkind" Modpack
+//====================================================================
+
+//  Remove the old non-reflective shader
+-KSP_MODEL_SHADER[ROC-ApolloD2] {}
+
+//  Re-apply the original shader again, but not on the models that need to be reflective.
+KSP_MODEL_SHADER
+{
+    name = ROC-ApolloD2
+
+    //model = ROCapsules/Assets/McDouble/D2/D2Adaptor
+    //model = ROCapsules/Assets/McDouble/D2/D2Antenna
+    model = ROCapsules/Assets/McDouble/D2/D2Block1LES
+    model = ROCapsules/Assets/McDouble/D2/D2Block1LESDecoupler
+    model = ROCapsules/Assets/McDouble/D2/D2Block2LES
+    //model = ROCapsules/Assets/McDouble/D2/D2Block2Nosecone
+    //model = ROCapsules/Assets/McDouble/D2/D2CM
+    //model = ROCapsules/Assets/McDouble/D2/D2DockDrogue
+    //model = ROCapsules/Assets/McDouble/D2/D2DockProbe
+    model = ROCapsules/Assets/McDouble/D2/D2Interstage
+    model = ROCapsules/Assets/McDouble/D2/D2Interstage2
+    model = ROCapsules/Assets/McDouble/D2/D2Interstage3
+    //model = ROCapsules/Assets/McDouble/D2/D2MissionModule1
+    //model = ROCapsules/Assets/McDouble/D2/D2MissionModule2
+    //model = ROCapsules/Assets/McDouble/D2/D2Parachute
+    model = ROCapsules/Assets/McDouble/D2/D2RCS
+    //model = ROCapsules/Assets/McDouble/D2/D2ServiceModule
+    //model = ROCapsules/Assets/McDouble/D2/D2Skirt1
+    //model = ROCapsules/Assets/McDouble/D2/D2Skirt2
+
+    MATERIAL
+    {
+        shader = TU/Metallic
+
+        PROPERTY
+        {
+            name = _Color
+            color = 1.5, 1.5, 1.5
+        }
+        PROPERTY
+        {
+            name = _Metal
+            float = 0.35
+        }
+        PROPERTY
+        {
+            name = _Smoothness
+            float = 0.35
+        }
+    }
+}
+
+//  Apply reflective TU effects to the remaining modules. Effect is roughly equivalent to BDB Apollo the way it is in RO.
+KSP_MODEL_SHADER
+{
+    name = ROC-ApolloD2-Reflective
+
+    model = ROCapsules/Assets/McDouble/D2/D2Adaptor
+    model = ROCapsules/Assets/McDouble/D2/D2Antenna
+    //model = ROCapsules/Assets/McDouble/D2/D2Block1LES
+    //model = ROCapsules/Assets/McDouble/D2/D2Block1LESDecoupler
+    //model = ROCapsules/Assets/McDouble/D2/D2Block2LES
+    model = ROCapsules/Assets/McDouble/D2/D2Block2Nosecone
+    model = ROCapsules/Assets/McDouble/D2/D2CM
+    model = ROCapsules/Assets/McDouble/D2/D2DockDrogue
+    model = ROCapsules/Assets/McDouble/D2/D2DockProbe
+    //model = ROCapsules/Assets/McDouble/D2/D2Interstage
+    //model = ROCapsules/Assets/McDouble/D2/D2Interstage2
+    //model = ROCapsules/Assets/McDouble/D2/D2Interstage3
+    model = ROCapsules/Assets/McDouble/D2/D2MissionModule1
+    model = ROCapsules/Assets/McDouble/D2/D2MissionModule2
+    model = ROCapsules/Assets/McDouble/D2/D2Parachute
+    //model = ROCapsules/Assets/McDouble/D2/D2RCS
+    model = ROCapsules/Assets/McDouble/D2/D2ServiceModule
+    model = ROCapsules/Assets/McDouble/D2/D2Skirt1
+    model = ROCapsules/Assets/McDouble/D2/D2Skirt2
+
+    MATERIAL
+    {
+        shader = TU/Metallic
+
+        PROPERTY
+        {
+            name = _Color
+            color = 1.5, 1.5, 1.5
+        }
+        PROPERTY
+        {
+            name = _Metal
+            float = 0.85
+        }
+        PROPERTY
+        {
+            name = _Smoothness
+            float = 0.95
+        }
+    }
+}


### PR DESCRIPTION
As discussed over Text and in VC, my side of the changes for FAK 1.8.0:

## Summary
1. Change crewed asteroid landing requirement.
2. Change tech tree node requirement for Hydrolox 1981 (SSME node).
3. Buff ion engines by a lot to make them usable in RO.
4. Improve AJ260 Thrust Curves and remove reflections to fix TU/Deferred/TUFX issues.
5. Fix various issues with Apollo D2 and add reflections.
6. Replace Lunar Transfer Planner with Target Intercept Planner (TIP).

> *CKAN File Version has been bumped.*

See individual commits for the actual changes that were made, I'm not gonna waste time summarising each commit again.