### PR TITLE
1.8.1 - fix: deduplicate tags to fix KCT multipliers

### DIFF
--- a/GameData/ForAllKerbalkind/Config/Career/NewRp1TreeParts.cfg
+++ b/GameData/ForAllKerbalkind/Config/Career/NewRp1TreeParts.cfg
@@ -1,12 +1,13 @@
 // New or altered part tech tree placement from v3.19.0.0 of RP-1.
+// > NOTE: Make sure you remove existing tags with "!MODULE[ModuleTagList],* {}" to avoid duplicates...
 @PART[0625_Heatshield]:AFTER[xxxRP0]
 {
     %TechRequired = humanRatedEDL
     %cost = 300
     %entryCost = 18000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -16,8 +17,8 @@
     %cost = 600
     %entryCost = 20000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -43,8 +44,8 @@
     %cost = 1500
     %entryCost = 25000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -62,8 +63,8 @@
     %cost = 15
     %entryCost = 2000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -73,8 +74,8 @@
     %cost = 4000
     %entryCost = 8000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     MODULE
     { name = ModuleNonReentryRated }
@@ -86,8 +87,8 @@
     %cost = 1956
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -97,8 +98,8 @@
     %cost = 526
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -108,8 +109,8 @@
     %cost = 159
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -127,8 +128,8 @@
     %cost = 917
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -139,8 +140,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -150,8 +151,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -161,8 +162,8 @@
     %cost = 8500
     %entryCost = 75000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -172,8 +173,8 @@
     %cost = 12500
     %entryCost = 25000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -183,8 +184,8 @@
     %cost = 12500
     %entryCost = 75000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -194,8 +195,8 @@
     %cost = 8500
     %entryCost = 18000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -205,8 +206,8 @@
     %cost = 8000
     %entryCost = 18000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -216,8 +217,8 @@
     %cost = 6500
     %entryCost = 15000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -227,8 +228,8 @@
     %cost = 12500
     %entryCost = 24000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -238,8 +239,8 @@
     %cost = 12500
     %entryCost = 24000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -249,8 +250,8 @@
     %cost = 16500
     %entryCost = 24000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -260,8 +261,8 @@
     %cost = 16500
     %entryCost = 24000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -271,8 +272,8 @@
     %cost = 1855
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -282,8 +283,8 @@
     %cost = 652
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -294,8 +295,8 @@
     %cost = 2727
     %entryCost = 192000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -306,8 +307,8 @@
     %cost = 60
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -317,8 +318,8 @@
     %cost = 72
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -328,8 +329,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -339,8 +340,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -350,8 +351,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -361,8 +362,8 @@
     %cost = 100
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -372,8 +373,8 @@
     %cost = 789
     %entryCost = 3500
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -383,8 +384,8 @@
     %cost = 2650
     %entryCost = 108000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -394,8 +395,8 @@
     %cost = 500
     %entryCost = 31000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -405,8 +406,8 @@
     %cost = 1500
     %entryCost = 33000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -416,8 +417,8 @@
     %cost = 3000
     %entryCost = 35000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -427,8 +428,8 @@
     %cost = 3600
     %entryCost = 36000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -438,8 +439,8 @@
     %cost = 7200
     %entryCost = 39000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -449,8 +450,8 @@
     %cost = 700
     %entryCost = 20000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -460,8 +461,8 @@
     %cost = 400
     %entryCost = 19000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -471,8 +472,8 @@
     %cost = 800
     %entryCost = 21000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -482,8 +483,8 @@
     %cost = 800
     %entryCost = 21000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -493,8 +494,8 @@
     %cost = 1100
     %entryCost = 22000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -504,8 +505,8 @@
     %cost = 1000
     %entryCost = 22000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -515,8 +516,8 @@
     %cost = 1500
     %entryCost = 25000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -526,8 +527,8 @@
     %cost = 1700
     %entryCost = 30000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -537,8 +538,8 @@
     %cost = 750
     %entryCost = 32000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -548,8 +549,8 @@
     %cost = 1850
     %entryCost = 33000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -559,8 +560,8 @@
     %cost = 2250
     %entryCost = 34000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -570,8 +571,8 @@
     %cost = 5400
     %entryCost = 38000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -581,8 +582,8 @@
     %cost = 20
     %entryCost = 2800
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -600,8 +601,8 @@
     %cost = 1444
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -756,8 +757,8 @@
     %cost = 1345
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -768,8 +769,8 @@
     %cost = 5437
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -780,8 +781,8 @@
     %cost = 200
     %entryCost = 3440
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -791,8 +792,8 @@
     %cost = 54
     %entryCost = 800
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -802,8 +803,8 @@
     %cost = 8550
     %entryCost = 280000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -816,8 +817,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -843,8 +844,8 @@
     %cost = 974
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -855,8 +856,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -866,8 +867,8 @@
     %cost = 33
     %entryCost = 6000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -877,8 +878,8 @@
     %cost = 5000
     %entryCost = 175000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -896,8 +897,8 @@
     %cost = 8000
     %entryCost = 280000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -910,8 +911,8 @@
     %cost = 8000
     %entryCost = 280000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -932,8 +933,8 @@
     %cost = 27
     %entryCost = 2800
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -943,8 +944,8 @@
     %cost = 26
     %entryCost = 2800
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -954,8 +955,8 @@
     %cost = 3000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Cockpit }
     MODULE
     { name = ModuleNoEVA }
@@ -970,8 +971,8 @@
     %cost = 2500
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Cockpit }
     MODULE
     { name = ModuleNoEVA }
@@ -986,8 +987,8 @@
     %cost = 5976
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -998,8 +999,8 @@
     %cost = 5788
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -1018,8 +1019,8 @@
     %cost = 136
     %entryCost = 50000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1029,8 +1030,8 @@
     %cost = 3965
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -1049,8 +1050,8 @@
     %cost = 6048
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -1061,8 +1062,8 @@
     %cost = 10924
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -1092,8 +1093,8 @@
     %cost = 606
     %entryCost = 13600
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1103,8 +1104,8 @@
     %cost = 620
     %entryCost = 14000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1114,8 +1115,8 @@
     %cost = 606
     %entryCost = 13600
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1133,8 +1134,8 @@
     %cost = 521
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1144,8 +1145,8 @@
     %cost = 2278
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -1156,8 +1157,8 @@
     %cost = 304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1175,8 +1176,8 @@
     %cost = 2020
     %entryCost = 66000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -1187,8 +1188,8 @@
     %cost = 1050
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -1207,8 +1208,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1218,8 +1219,8 @@
     %cost = 166
     %entryCost = 1640
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -1245,8 +1246,8 @@
     %cost = 73
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -1256,8 +1257,8 @@
     %cost = 47
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1278,8 +1279,8 @@
     %cost = 250
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -1289,8 +1290,8 @@
     %cost = 624
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1300,8 +1301,8 @@
     %cost = 250
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -1311,8 +1312,8 @@
     %cost = 100
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -1426,8 +1427,8 @@
     %cost = 7441
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -1438,8 +1439,8 @@
     %cost = 22
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -1449,8 +1450,8 @@
     %cost = 159
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1471,8 +1472,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -1482,8 +1483,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -1493,8 +1494,8 @@
     %cost = 248
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1504,8 +1505,8 @@
     %cost = 276
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1515,8 +1516,8 @@
     %cost = 387
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1552,8 +1553,8 @@
     %cost = 115
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1563,8 +1564,8 @@
     %cost = 521
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1574,8 +1575,8 @@
     %cost = 489
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1585,8 +1586,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1604,8 +1605,8 @@
     %cost = 392
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1615,8 +1616,8 @@
     %cost = 165
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -1699,8 +1700,8 @@
     %cost = 17
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2129,8 +2130,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2140,8 +2141,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2151,8 +2152,8 @@
     %cost = 159
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2194,8 +2195,8 @@
     %cost = 166
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Toxic }
 
 }
@@ -2205,8 +2206,8 @@
     %cost = 13000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     MODULE
     { name = ModuleNoEVA }
@@ -2220,8 +2221,8 @@
     %cost = 4500
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
@@ -2232,8 +2233,8 @@
     %cost = 1
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -2273,8 +2274,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2284,8 +2285,8 @@
     %cost = 8000
     %entryCost = 280000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -2298,8 +2299,8 @@
     %cost = 7450
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -2337,8 +2338,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2348,8 +2349,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2433,8 +2434,8 @@
     %cost = 2
     %entryCost = 40
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -2444,8 +2445,8 @@
     %cost = 2
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -2463,8 +2464,8 @@
     %cost = 25
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -2474,8 +2475,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2485,8 +2486,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2496,8 +2497,8 @@
     %cost = 270
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2507,8 +2508,8 @@
     %cost = 270
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2518,8 +2519,8 @@
     %cost = 159
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2529,8 +2530,8 @@
     %cost = 88
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2540,8 +2541,8 @@
     %cost = 138
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2551,8 +2552,8 @@
     %cost = 73
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2562,8 +2563,8 @@
     %cost = 73
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2573,8 +2574,8 @@
     %cost = 52
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2584,8 +2585,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2606,8 +2607,8 @@
     %cost = 18
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2617,8 +2618,8 @@
     %cost = 18
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2628,8 +2629,8 @@
     %cost = 47
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2639,8 +2640,8 @@
     %cost = 47
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2650,8 +2651,8 @@
     %cost = 47
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2661,8 +2662,8 @@
     %cost = 47
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2672,8 +2673,8 @@
     %cost = 41
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2716,8 +2717,8 @@
     %cost = 917
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2728,8 +2729,8 @@
     %cost = 917
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2740,8 +2741,8 @@
     %cost = 1332
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2751,8 +2752,8 @@
     %cost = 4316
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -2763,8 +2764,8 @@
     %cost = 8
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2774,8 +2775,8 @@
     %cost = 624
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2785,8 +2786,8 @@
     %cost = 624
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2796,8 +2797,8 @@
     %cost = 1855
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2807,8 +2808,8 @@
     %cost = 1855
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2818,8 +2819,8 @@
     %cost = 2125
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2840,8 +2841,8 @@
     %cost = 106
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2851,8 +2852,8 @@
     %cost = 108
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2862,8 +2863,8 @@
     %cost = 174
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2873,8 +2874,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2884,8 +2885,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2895,8 +2896,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2906,8 +2907,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -2917,8 +2918,8 @@
     %cost = 2265
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2929,8 +2930,8 @@
     %cost = 428
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2941,8 +2942,8 @@
     %cost = 10
     %entryCost = 3000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2952,8 +2953,8 @@
     %cost = 10
     %entryCost = 3000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -2963,8 +2964,8 @@
     %cost = 1444
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2975,8 +2976,8 @@
     %cost = 1444
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2987,8 +2988,8 @@
     %cost = 2020
     %entryCost = 66000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -2999,8 +3000,8 @@
     %cost = 3458
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3011,8 +3012,8 @@
     %cost = 3458
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3023,8 +3024,8 @@
     %cost = 163
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3034,8 +3035,8 @@
     %cost = 59
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3045,8 +3046,8 @@
     %cost = 58
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3056,8 +3057,8 @@
     %cost = 107
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3067,8 +3068,8 @@
     %cost = 652
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3079,8 +3080,8 @@
     %cost = 2727
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3091,8 +3092,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3102,8 +3103,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3113,8 +3114,8 @@
     %cost = 38
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3157,8 +3158,8 @@
     %cost = 276
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3179,8 +3180,8 @@
     %cost = 3263
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3191,8 +3192,8 @@
     %cost = 387
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3202,8 +3203,8 @@
     %cost = 387
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3213,8 +3214,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3224,8 +3225,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3235,8 +3236,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3246,8 +3247,8 @@
     %cost = 364
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3257,8 +3258,8 @@
     %cost = 974
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3269,8 +3270,8 @@
     %cost = 974
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3281,8 +3282,8 @@
     %cost = 364
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3292,8 +3293,8 @@
     %cost = 248
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3314,8 +3315,8 @@
     %cost = 325
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3325,8 +3326,8 @@
     %cost = 325
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3336,8 +3337,8 @@
     %cost = 4914
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3359,8 +3360,8 @@
     %cost = 1252
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3371,8 +3372,8 @@
     %cost = 1752
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3415,8 +3416,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3426,8 +3427,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3437,8 +3438,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3448,8 +3449,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3459,8 +3460,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3470,8 +3471,8 @@
     %cost = 7304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -3482,8 +3483,8 @@
     %cost = 11596
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -3494,8 +3495,8 @@
     %cost = 5788
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -3506,8 +3507,8 @@
     %cost = 781
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3517,8 +3518,8 @@
     %cost = 781
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3528,8 +3529,8 @@
     %cost = 653
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3539,8 +3540,8 @@
     %cost = 653
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3550,8 +3551,8 @@
     %cost = 401
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3561,8 +3562,8 @@
     %cost = 429
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3572,8 +3573,8 @@
     %cost = 34
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3583,8 +3584,8 @@
     %cost = 18
     %entryCost = 3000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3594,8 +3595,8 @@
     %cost = 18
     %entryCost = 3000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3605,8 +3606,8 @@
     %cost = 15
     %entryCost = 2000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3616,8 +3617,8 @@
     %cost = 15
     %entryCost = 2000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -3627,8 +3628,8 @@
     %cost = 115
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3638,8 +3639,8 @@
     %cost = 115
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3649,8 +3650,8 @@
     %cost = 304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3660,8 +3661,8 @@
     %cost = 304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3671,8 +3672,8 @@
     %cost = 188
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3682,8 +3683,8 @@
     %cost = 5549
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3694,8 +3695,8 @@
     %cost = 521
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3705,8 +3706,8 @@
     %cost = 820
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -3717,8 +3718,8 @@
     %cost = 362
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3728,8 +3729,8 @@
     %cost = 489
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3739,8 +3740,8 @@
     %cost = 526
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3750,8 +3751,8 @@
     %cost = 419
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3761,8 +3762,8 @@
     %cost = 23
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3772,8 +3773,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3783,8 +3784,8 @@
     %cost = 320
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3794,8 +3795,8 @@
     %cost = 606
     %entryCost = 13600
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3805,8 +3806,8 @@
     %cost = 606
     %entryCost = 13600
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3816,8 +3817,8 @@
     %cost = 620
     %entryCost = 14000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3827,8 +3828,8 @@
     %cost = 620
     %entryCost = 14000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3838,8 +3839,8 @@
     %cost = 196
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3849,8 +3850,8 @@
     %cost = 576
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3860,8 +3861,8 @@
     %cost = 789
     %entryCost = 3500
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3871,8 +3872,8 @@
     %cost = 2650
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3882,8 +3883,8 @@
     %cost = 2650
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3893,8 +3894,8 @@
     %cost = 1700
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3904,8 +3905,8 @@
     %cost = 1700
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3915,8 +3916,8 @@
     %cost = 1100
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3926,8 +3927,8 @@
     %cost = 1100
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3937,8 +3938,8 @@
     %cost = 109
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3948,8 +3949,8 @@
     %cost = 278
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3959,8 +3960,8 @@
     %cost = 784
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3970,8 +3971,8 @@
     %cost = 392
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3981,8 +3982,8 @@
     %cost = 367
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -3992,8 +3993,8 @@
     %cost = 796
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4003,8 +4004,8 @@
     %cost = 2185
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4014,8 +4015,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4025,8 +4026,8 @@
     %cost = 477
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4036,8 +4037,8 @@
     %cost = 1601
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4048,8 +4049,8 @@
     %cost = 165
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4059,8 +4060,8 @@
     %cost = 165
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4070,8 +4071,8 @@
     %cost = 49
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4081,8 +4082,8 @@
     %cost = 24
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4092,8 +4093,8 @@
     %cost = 13
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4103,8 +4104,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4115,8 +4116,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4127,8 +4128,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4139,8 +4140,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4151,8 +4152,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4163,8 +4164,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4175,8 +4176,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4187,8 +4188,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4199,8 +4200,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4211,8 +4212,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4223,8 +4224,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4235,8 +4236,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4247,8 +4248,8 @@
     %cost = 5704
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4259,8 +4260,8 @@
     %cost = 5704
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4271,8 +4272,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4282,8 +4283,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4294,8 +4295,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4306,8 +4307,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4318,8 +4319,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4329,8 +4330,8 @@
     %cost = 301
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4341,8 +4342,8 @@
     %cost = 17
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4352,8 +4353,8 @@
     %cost = 1608
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4363,8 +4364,8 @@
     %cost = 1608
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4374,8 +4375,8 @@
     %cost = 60
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4385,8 +4386,8 @@
     %cost = 60
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4396,8 +4397,8 @@
     %cost = 72
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4407,8 +4408,8 @@
     %cost = 72
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4418,8 +4419,8 @@
     %cost = 138
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4429,8 +4430,8 @@
     %cost = 184
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { %isDynamic = true }
 
 }
@@ -4440,8 +4441,8 @@
     %cost = 184
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { %isDynamic = true }
 
 }
@@ -4451,8 +4452,8 @@
     %cost = 198
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4478,8 +4479,8 @@
     %cost = 136
     %entryCost = 50000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4489,8 +4490,8 @@
     %cost = 136
     %entryCost = 50000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4500,8 +4501,8 @@
     %cost = 7102
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -4589,8 +4590,8 @@
     %cost = 135
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4600,8 +4601,8 @@
     %cost = 89
     %entryCost = 1240
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4611,8 +4612,8 @@
     %cost = 89
     %entryCost = 1240
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4622,8 +4623,8 @@
     %cost = 178
     %entryCost = 1240
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4633,8 +4634,8 @@
     %cost = 178
     %entryCost = 1240
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4644,8 +4645,8 @@
     %cost = 27
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4655,8 +4656,8 @@
     %cost = 27
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4699,8 +4700,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4710,8 +4711,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4721,8 +4722,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4732,8 +4733,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4743,8 +4744,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4754,8 +4755,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4765,8 +4766,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4776,8 +4777,8 @@
     %cost = 114
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4787,8 +4788,8 @@
     %cost = 163
     %entryCost = 3000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { %isDynamic = true }
 
 }
@@ -4798,8 +4799,8 @@
     %cost = 200
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4809,8 +4810,8 @@
     %cost = 330
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4820,8 +4821,8 @@
     %cost = 333
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4831,8 +4832,8 @@
     %cost = 1132
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4842,8 +4843,8 @@
     %cost = 4527
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4854,8 +4855,8 @@
     %cost = 17
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -4865,8 +4866,8 @@
     %cost = 1852
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4876,8 +4877,8 @@
     %cost = 5294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4888,8 +4889,8 @@
     %cost = 4349
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4900,8 +4901,8 @@
     %cost = 784
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4912,8 +4913,8 @@
     %cost = 156
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -4935,8 +4936,8 @@
     %cost = 5801
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4947,8 +4948,8 @@
     %cost = 7796
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -4970,8 +4971,8 @@
     %cost = 136
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -5075,8 +5076,8 @@
     %cost = 1561
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5086,8 +5087,8 @@
     %cost = 1523
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5097,8 +5098,8 @@
     %cost = 912
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5108,8 +5109,8 @@
     %cost = 180
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5119,8 +5120,8 @@
     %cost = 571
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5130,8 +5131,8 @@
     %cost = 25
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5141,8 +5142,8 @@
     %cost = 392
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5152,8 +5153,8 @@
     %cost = 23
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5163,8 +5164,8 @@
     %cost = 721
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5174,8 +5175,8 @@
     %cost = 2493
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5186,8 +5187,8 @@
     %cost = 41
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5197,8 +5198,8 @@
     %cost = 1436
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5209,8 +5210,8 @@
     %cost = 5097
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5221,8 +5222,8 @@
     %cost = 994
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5233,8 +5234,8 @@
     %cost = 2912
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5244,8 +5245,8 @@
     %cost = 6910
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5256,8 +5257,8 @@
     %cost = 2713
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5278,8 +5279,8 @@
     %cost = 3024
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5289,8 +5290,8 @@
     %cost = 1200
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5300,8 +5301,8 @@
     %cost = 1200
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5311,8 +5312,8 @@
     %cost = 4809
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5444,8 +5445,8 @@
     %cost = 0
     %entryCost = 50000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5455,8 +5456,8 @@
     %cost = 0
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5466,8 +5467,8 @@
     %cost = 1
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5477,8 +5478,8 @@
     %cost = 0
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5488,8 +5489,8 @@
     %cost = 1
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5510,8 +5511,8 @@
     %cost = 1
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5521,8 +5522,8 @@
     %cost = 1
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5532,8 +5533,8 @@
     %cost = 0
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -5543,8 +5544,8 @@
     %cost = 0
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5554,8 +5555,8 @@
     %cost = 0
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -5577,8 +5578,8 @@
     %cost = 0
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5588,8 +5589,8 @@
     %cost = 0
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -5599,8 +5600,8 @@
     %cost = 0
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5610,8 +5611,8 @@
     %cost = 0
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5633,8 +5634,8 @@
     %cost = 0
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankIsogrid }
 
 }
@@ -5652,8 +5653,8 @@
     %cost = 480
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5664,8 +5665,8 @@
     %cost = 300
     %entryCost = 18000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5675,8 +5676,8 @@
     %cost = 600
     %entryCost = 20000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5686,8 +5687,8 @@
     %cost = 700
     %entryCost = 20000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5697,8 +5698,8 @@
     %cost = 400
     %entryCost = 19000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5708,8 +5709,8 @@
     %cost = 800
     %entryCost = 21000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5719,8 +5720,8 @@
     %cost = 800
     %entryCost = 21000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5730,8 +5731,8 @@
     %cost = 800
     %entryCost = 21000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5741,8 +5742,8 @@
     %cost = 1000
     %entryCost = 22000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5752,8 +5753,8 @@
     %cost = 1500
     %entryCost = 25000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5763,8 +5764,8 @@
     %cost = 1700
     %entryCost = 30000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5774,8 +5775,8 @@
     %cost = 2200
     %entryCost = 30000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -5785,8 +5786,8 @@
     %cost = 4914
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5808,8 +5809,8 @@
     %cost = 166
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -5819,8 +5820,8 @@
     %cost = 101
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -5830,8 +5831,8 @@
     %cost = 1855
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5841,8 +5842,8 @@
     %cost = 1969
     %entryCost = 409361
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5852,8 +5853,8 @@
     %cost = 2125
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5863,8 +5864,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5874,8 +5875,8 @@
     %cost = 428
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5886,8 +5887,8 @@
     %cost = 1444
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5898,8 +5899,8 @@
     %cost = 3458
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5910,8 +5911,8 @@
     %cost = 38
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5921,8 +5922,8 @@
     %cost = 1700
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5932,8 +5933,8 @@
     %cost = 5704
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5944,8 +5945,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5956,8 +5957,8 @@
     %cost = 394
     %entryCost = 8000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5967,8 +5968,8 @@
     %cost = 2095
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -5979,8 +5980,8 @@
     %cost = 47
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -5990,8 +5991,8 @@
     %cost = 18
     %entryCost = 3000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6001,8 +6002,8 @@
     %cost = 80
     %entryCost = 8000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6031,8 +6032,8 @@
     %cost = 60
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6042,8 +6043,8 @@
     %cost = 72
     %entryCost = 20000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6214,8 +6215,8 @@
     %cost = 5704
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -6226,8 +6227,8 @@
     %cost = 52
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6237,8 +6238,8 @@
     %cost = 73
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6248,8 +6249,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6259,8 +6260,8 @@
     %cost = 174
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6270,8 +6271,8 @@
     %cost = 106
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6281,8 +6282,8 @@
     %cost = 5549
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -6293,8 +6294,8 @@
     %cost = 5320
     %entryCost = 106400
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Cockpit }
     MODULE
     { name = ModuleNoEVA }
@@ -6309,8 +6310,8 @@
     %cost = 2650
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6320,8 +6321,8 @@
     %cost = 1444
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -6332,8 +6333,8 @@
     %cost = 4316
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -6344,8 +6345,8 @@
     %cost = 11596
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -6404,8 +6405,8 @@
     %cost = 100
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6415,8 +6416,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6426,8 +6427,8 @@
     %cost = 2000
     %entryCost = 2500
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6453,8 +6454,8 @@
     %cost = 6250
     %entryCost = 860000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6464,8 +6465,8 @@
     %cost = 620
     %entryCost = 14000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6475,8 +6476,8 @@
     %cost = 1855
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -6486,8 +6487,8 @@
     %cost = 22816
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -6498,8 +6499,8 @@
     %cost = 1650
     %entryCost = 32000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -6509,8 +6510,8 @@
     %cost = 800
     %entryCost = 21000
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Reentry }
 
 }
@@ -6520,8 +6521,8 @@
     %cost = 178
     %entryCost = 1240
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6531,8 +6532,8 @@
     %cost = 89
     %entryCost = 1240
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6542,8 +6543,8 @@
     %cost = 1
     %entryCost = 40
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6553,8 +6554,8 @@
     %cost = 27
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -6620,8 +6621,8 @@
     %cost = 50
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -6679,8 +6680,8 @@
     %cost = 2000
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Avionics }
 
 }
@@ -6690,8 +6691,8 @@
     %cost = 500
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6701,8 +6702,8 @@
     %cost = 50
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -6712,8 +6713,8 @@
     %cost = 5
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -6723,8 +6724,8 @@
     %cost = 1
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6750,8 +6751,8 @@
     %cost = 1
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6769,8 +6770,8 @@
     %cost = 1
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6780,8 +6781,8 @@
     %cost = 1
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6791,8 +6792,8 @@
     %cost = 26726
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = NuclearRTG }
 
 }
@@ -6802,8 +6803,8 @@
     %cost = 2100
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6813,8 +6814,8 @@
     %cost = 5
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -6824,8 +6825,8 @@
     %cost = 2100
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -6835,8 +6836,8 @@
     %cost = 50
     %entryCost = 0
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = TankServiceModule }
 
 }
@@ -7059,8 +7060,8 @@
     %cost = 165
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7086,8 +7087,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7098,8 +7099,8 @@
     %cost = 5000
     %entryCost = 175000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -7109,8 +7110,8 @@
     %cost = 159
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7136,8 +7137,8 @@
     %cost = 38
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7147,8 +7148,8 @@
     %cost = 38
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7158,8 +7159,8 @@
     %cost = 276
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7169,8 +7170,8 @@
     %cost = 248
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7180,8 +7181,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7192,8 +7193,8 @@
     %cost = 294
     %entryCost = 26000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7204,8 +7205,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7215,8 +7216,8 @@
     %cost = 73
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7234,8 +7235,8 @@
     %cost = 1855
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7245,8 +7246,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7256,8 +7257,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7267,8 +7268,8 @@
     %cost = 1444
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7279,8 +7280,8 @@
     %cost = 2020
     %entryCost = 66000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7291,8 +7292,8 @@
     %cost = 387
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7302,8 +7303,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7313,8 +7314,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7324,8 +7325,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7335,8 +7336,8 @@
     %cost = 325
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7346,8 +7347,8 @@
     %cost = 325
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7357,8 +7358,8 @@
     %cost = 73
     %entryCost = 43000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7368,8 +7369,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7379,8 +7380,8 @@
     %cost = 52
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7390,8 +7391,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7401,8 +7402,8 @@
     %cost = 41
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7412,8 +7413,8 @@
     %cost = 270
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7423,8 +7424,8 @@
     %cost = 387
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7434,8 +7435,8 @@
     %cost = 152
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7453,8 +7454,8 @@
     %cost = 27
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7472,8 +7473,8 @@
     %cost = 107
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7483,8 +7484,8 @@
     %cost = 278
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7494,8 +7495,8 @@
     %cost = 196
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7505,8 +7506,8 @@
     %cost = 4316
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -7517,8 +7518,8 @@
     %cost = 784
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7528,8 +7529,8 @@
     %cost = 784
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7539,8 +7540,8 @@
     %cost = 198
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7550,8 +7551,8 @@
     %cost = 2095
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7562,8 +7563,8 @@
     %cost = 2727
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7574,8 +7575,8 @@
     %cost = 3458
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7586,8 +7587,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7598,8 +7599,8 @@
     %cost = 5549
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7610,8 +7611,8 @@
     %cost = 1200
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7621,8 +7622,8 @@
     %cost = 293
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7632,8 +7633,8 @@
     %cost = 1608
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7643,8 +7644,8 @@
     %cost = 1608
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7654,8 +7655,8 @@
     %cost = 5549
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7666,8 +7667,8 @@
     %cost = 3953
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7678,8 +7679,8 @@
     %cost = 2812
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7690,8 +7691,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -7701,8 +7702,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7713,8 +7714,8 @@
     %cost = 1332
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7724,8 +7725,8 @@
     %cost = 1050
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7736,8 +7737,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7748,8 +7749,8 @@
     %cost = 1050
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7760,8 +7761,8 @@
     %cost = 1608
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7771,8 +7772,8 @@
     %cost = 3458
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7783,8 +7784,8 @@
     %cost = 2095
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7827,8 +7828,8 @@
     %cost = 136
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -7854,8 +7855,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -7866,8 +7867,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8221,8 +8222,8 @@
     %cost = 3000
     %entryCost = 60000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -8235,8 +8236,8 @@
     %cost = 2000
     %entryCost = 40000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -8265,8 +8266,8 @@
     %cost = 781
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8276,8 +8277,8 @@
     %cost = 653
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8287,8 +8288,8 @@
     %cost = 429
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8298,8 +8299,8 @@
     %cost = 276
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8309,8 +8310,8 @@
     %cost = 387
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8320,8 +8321,8 @@
     %cost = 165
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8331,8 +8332,8 @@
     %cost = 142
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -8342,8 +8343,8 @@
     %cost = 77
     %entryCost = 14000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8353,8 +8354,8 @@
     %cost = 1332
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8364,8 +8365,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -8375,8 +8376,8 @@
     %cost = 1
     %entryCost = 60
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -8434,8 +8435,8 @@
     %cost = 15000
     %entryCost = 300000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -8448,8 +8449,8 @@
     %cost = 6000
     %entryCost = 120000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
     MODULE
@@ -8462,8 +8463,8 @@
     %cost = 2000
     %entryCost = 40000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Avionics }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
@@ -8514,8 +8515,8 @@
     %cost = 4500
     %entryCost = 90000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     MODULE
     { name = ModuleNonReentryRated }
@@ -8527,8 +8528,8 @@
     %cost = 4500
     %entryCost = 90000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     MODULE
     { name = ModuleNonReentryRated }
@@ -8667,8 +8668,8 @@
     %cost = 10
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -8678,8 +8679,8 @@
     %cost = 10
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -8689,8 +8690,8 @@
     %cost = 10
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -8711,8 +8712,8 @@
     %cost = 20
     %entryCost = 2000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = Instruments }
 
 }
@@ -8766,8 +8767,8 @@
     %cost = 1852
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8777,8 +8778,8 @@
     %cost = 11112
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8788,8 +8789,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8799,8 +8800,8 @@
     %cost = 327
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8810,8 +8811,8 @@
     %cost = 2493
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -8822,8 +8823,8 @@
     %cost = 1634
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -8834,8 +8835,8 @@
     %cost = 2713
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8845,8 +8846,8 @@
     %cost = 1200
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8856,8 +8857,8 @@
     %cost = 2180
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8875,8 +8876,8 @@
     %cost = 1485
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -8887,8 +8888,8 @@
     %cost = 7304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -8899,8 +8900,8 @@
     %cost = 11596
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -8911,8 +8912,8 @@
     %cost = 4316
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -8923,8 +8924,8 @@
     %cost = 7304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -8951,8 +8952,8 @@
     %cost = 88
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -8962,8 +8963,8 @@
     %cost = 38
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -8973,8 +8974,8 @@
     %cost = 24
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9016,8 +9017,8 @@
     %cost = 77
     %entryCost = 11000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9027,8 +9028,8 @@
     %cost = 373
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9038,8 +9039,8 @@
     %cost = 294
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -9050,8 +9051,8 @@
     %cost = 2125
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9061,8 +9062,8 @@
     %cost = 2278
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     %MODULE[ModuleTagList] { tag = Nuclear }
 
@@ -9073,8 +9074,8 @@
     %cost = 392
     %entryCost = 4000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9186,8 +9187,8 @@
     %cost = 63
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -9197,8 +9198,8 @@
     %cost = 52
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -9208,8 +9209,8 @@
     %cost = 27000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9219,8 +9220,8 @@
     %cost = 136
     %entryCost = 50000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9230,8 +9231,8 @@
     %cost = 571
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9241,8 +9242,8 @@
     %cost = 25
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9252,8 +9253,8 @@
     %cost = 721
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9263,8 +9264,8 @@
     %cost = 196
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9274,8 +9275,8 @@
     %cost = 278
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9285,8 +9286,8 @@
     %cost = 392
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9296,8 +9297,8 @@
     %cost = 2000
     %entryCost = 40000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
     MODULE
     { name = ModuleNonReentryRated }
@@ -9309,8 +9310,8 @@
     %cost = 126
     %entryCost = 9000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9320,8 +9321,8 @@
     %cost = 128
     %entryCost = 9000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9331,8 +9332,8 @@
     %cost = 126
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9342,8 +9343,8 @@
     %cost = 4
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9361,8 +9362,8 @@
     %cost = 387
     %entryCost = 13000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9372,8 +9373,8 @@
     %cost = 364
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9383,8 +9384,8 @@
     %cost = 325
     %entryCost = 8000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9394,8 +9395,8 @@
     %cost = 10
     %entryCost = 1000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9413,8 +9414,8 @@
     %cost = 728
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9440,8 +9441,8 @@
     %cost = 5000
     %entryCost = 175000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -9451,8 +9452,8 @@
     %cost = 387
     %entryCost = 13000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9462,8 +9463,8 @@
     %cost = 27
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -9473,8 +9474,8 @@
     %cost = 152
     %entryCost = 12000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9484,8 +9485,8 @@
     %cost = 152
     %entryCost = 500
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9495,8 +9496,8 @@
     %cost = 789
     %entryCost = 3500
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9506,8 +9507,8 @@
     %cost = 194
     %entryCost = 4200
     %RP0conf = false
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9541,8 +9542,8 @@
     %cost = 5000
     %entryCost = 175000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -9570,8 +9571,8 @@
     %cost = 40
     %entryCost = 3000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -9581,8 +9582,8 @@
     %cost = 240
     %entryCost = 5000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineSolid }
 
 }
@@ -9592,8 +9593,8 @@
     %cost = 13
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -9662,8 +9663,8 @@
     %cost = 10000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9673,8 +9674,8 @@
     %cost = 3000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9684,8 +9685,8 @@
     %cost = 4000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9695,8 +9696,8 @@
     %cost = 4000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9706,8 +9707,8 @@
     %cost = 5000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9717,8 +9718,8 @@
     %cost = 10000
     %entryCost = 100000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9728,8 +9729,8 @@
     %cost = 1500
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9739,8 +9740,8 @@
     %cost = 1500
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9750,8 +9751,8 @@
     %cost = 2000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9761,8 +9762,8 @@
     %cost = 2000
     %entryCost = 20000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9772,8 +9773,8 @@
     %cost = 2000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9783,8 +9784,8 @@
     %cost = 20000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9794,8 +9795,8 @@
     %cost = 30000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9805,8 +9806,8 @@
     %cost = 30000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9816,8 +9817,8 @@
     %cost = 30000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9827,8 +9828,8 @@
     %cost = 50000
     %entryCost = 500000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9838,8 +9839,8 @@
     %cost = 40000
     %entryCost = 400000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9849,8 +9850,8 @@
     %cost = 80000
     %entryCost = 800000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9868,8 +9869,8 @@
     %cost = 5000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9879,8 +9880,8 @@
     %cost = 10000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9890,8 +9891,8 @@
     %cost = 30000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9901,8 +9902,8 @@
     %cost = 5000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9912,8 +9913,8 @@
     %cost = 6000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9923,8 +9924,8 @@
     %cost = 5000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9934,8 +9935,8 @@
     %cost = 6000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9945,8 +9946,8 @@
     %cost = 10000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9956,8 +9957,8 @@
     %cost = 8000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9967,8 +9968,8 @@
     %cost = 6000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9978,8 +9979,8 @@
     %cost = 30000
     %entryCost = 300000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -9989,8 +9990,8 @@
     %cost = 20000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10000,8 +10001,8 @@
     %cost = 14000
     %entryCost = 14000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10011,8 +10012,8 @@
     %cost = 10000
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10022,8 +10023,8 @@
     %cost = 20000
     %entryCost = 20000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10033,8 +10034,8 @@
     %cost = 7000
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10044,8 +10045,8 @@
     %cost = 5000
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10055,8 +10056,8 @@
     %cost = 5000
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10066,8 +10067,8 @@
     %cost = 15000
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10077,8 +10078,8 @@
     %cost = 10000
     %entryCost = 10000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10088,8 +10089,8 @@
     %cost = 15000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10099,8 +10100,8 @@
     %cost = 30000
     %entryCost = 300000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10110,8 +10111,8 @@
     %cost = 30000
     %entryCost = 300000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10121,8 +10122,8 @@
     %cost = 20000
     %entryCost = 200000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10132,8 +10133,8 @@
     %cost = 3000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10143,8 +10144,8 @@
     %cost = 8000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10154,8 +10155,8 @@
     %cost = 1000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10165,8 +10166,8 @@
     %cost = 3000
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = HumanRated }
 
 }
@@ -10232,8 +10233,8 @@
     %cost = 18
     %entryCost = 1
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidPF }
 
 }
@@ -10243,8 +10244,8 @@
     %cost = 5549
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 
@@ -10255,8 +10256,8 @@
     %cost = 789
     %entryCost = 3500
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10266,8 +10267,8 @@
     %cost = 2650
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10277,8 +10278,8 @@
     %cost = 392
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10288,8 +10289,8 @@
     %cost = 367
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10299,8 +10300,8 @@
     %cost = 24
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10310,8 +10311,8 @@
     %cost = 13
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10321,8 +10322,8 @@
     %cost = 49
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10332,8 +10333,8 @@
     %cost = 620
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10343,8 +10344,8 @@
     %cost = 304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10354,8 +10355,8 @@
     %cost = 606
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10365,8 +10366,8 @@
     %cost = 304
     %entryCost = 0
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
@@ -10376,8 +10377,8 @@
     %cost = 2020
     %entryCost = 66000
     %RP0conf = true
-    
 
+    !MODULE[ModuleTagList],* {}
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
     
 


### PR DESCRIPTION
## Critical Bugfix to address duplicate KCT Multiplier Issue

**Removes the TagList Module from any parts we touch here first, so we can then safely apply our own TagList without duplicating the KCT tags.**

This resolves a ciritcal issue where any parts we change in [NewRp1TreeParts.cfg](https://github.com/TheBeardyPenguin/ForAllKerbalkind/blob/main/GameData/ForAllKerbalkind/Config/Career/NewRp1TreeParts.cfg) had their tags duplicated (and thus KCT Multipliers applied twice), leading to exponential cost increases on high-complexity rockets (such as Crewed or Nuclear rockets).

> *Thanks user MetalSpiderPig for reporting this!*